### PR TITLE
[IBCDPE-1034] Move deployment model to ArgoCD

### DIFF
--- a/modules/victoria-metrics/versions.tf
+++ b/modules/victoria-metrics/versions.tf
@@ -8,10 +8,6 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.0"
     }
-    helm = {
-      source  = "hashicorp/helm"
-      version = "~> 2.0"
-    }
     kubectl = {
       source  = "gavinbunney/kubectl"
       version = "1.14.0"


### PR DESCRIPTION
**Problem:**

1. When a helm release fails during a Terraform apply the "blast radius" can be quite large and put the Terraform state into a bad state that requires quite a lot of "massaging" to get it back into a working state.

**Solution:**

1. Move the deployment model to ArgoCD which has significantly better tooling to handle deploying of kubernetes resources.
2. Terraform is responsible for deploying the initial set of applications to K8s, in addition to the resource definitions that ArgoCD uses to deploy further applications on the cluster.
3. Docs on ArgoCD: https://argo-cd.readthedocs.io/en/stable/

**Overview of deployment steps:**

1. Spacelift deploys out spacelift specific resources like the 2 stacks (Infrastructure, and k8s deployment resources)
2. The Infrastrucure stack deploys out the VPC, the EKS cluster, and several security roles required to run the EKS cluster.
3. The K8s deployment resources deploys out the K8s auto scaler, some EKS add ons (That require a node to be running), ArgoCD via the helm terraform provider, and a number of kubernetes resources that configure ArgoCD
4. ArgoCD then deploys any applications defined in the previous step (either manually) or automatically if auto deploy is turned on.

**Testing:**

1.Tested the deployment of the cluster to K8s and deploying the applications via ArgoCD