### PR TITLE
[IBCDPE-1007] Manual guardduty install

### DIFF
--- a/deployments/spacelift/dpe-k8s/main.tf
+++ b/deployments/spacelift/dpe-k8s/main.tf
@@ -18,6 +18,7 @@ locals {
     auto_deploy      = var.auto_deploy
     auto_prune       = var.auto_prune
     git_revision     = var.git_branch
+    aws_account_id   = var.aws_account_id
   }
 
   # Variables to be passed from the k8s stack to the deployments stack

--- a/deployments/stacks/dpe-k8s-deployments/main.tf
+++ b/deployments/stacks/dpe-k8s-deployments/main.tf
@@ -10,9 +10,8 @@ module "sage-aws-eks-autoscaler" {
 }
 
 module "sage-aws-eks-addons" {
-  # source       = "spacelift.io/sagebionetworks/sage-aws-eks-addons/aws"
-  # version      = "0.2.0"
-  source             = "../../../modules/sage-aws-eks-addons"
+  source             = "spacelift.io/sagebionetworks/sage-aws-eks-addons/aws"
+  version            = "0.3.0"
   cluster_name       = var.cluster_name
   aws_account_id     = var.aws_account_id
   vpc_id             = var.vpc_id

--- a/deployments/stacks/dpe-k8s-deployments/main.tf
+++ b/deployments/stacks/dpe-k8s-deployments/main.tf
@@ -10,9 +10,13 @@ module "sage-aws-eks-autoscaler" {
 }
 
 module "sage-aws-eks-addons" {
-  source       = "spacelift.io/sagebionetworks/sage-aws-eks-addons/aws"
-  version      = "0.2.0"
-  cluster_name = var.cluster_name
+  # source       = "spacelift.io/sagebionetworks/sage-aws-eks-addons/aws"
+  # version      = "0.2.0"
+  source             = "../../../modules/sage-aws-eks-addons"
+  cluster_name       = var.cluster_name
+  aws_account_id     = var.aws_account_id
+  vpc_id             = var.vpc_id
+  private_subnet_ids = var.private_subnet_ids
 }
 
 module "argo-cd" {

--- a/deployments/stacks/dpe-k8s-deployments/variables.tf
+++ b/deployments/stacks/dpe-k8s-deployments/variables.tf
@@ -60,3 +60,8 @@ variable "git_revision" {
   type        = string
   default     = "main"
 }
+
+variable "aws_account_id" {
+  description = "AWS account ID"
+  type        = string
+}

--- a/modules/main.tf
+++ b/modules/main.tf
@@ -62,11 +62,12 @@ locals {
       name               = "sage-aws-eks-addons"
       terraform_provider = "aws"
       administrative     = false
-      branch             = var.git_branch
-      description        = "Terraform module for add-ons for an EKS cluster in AWS"
-      project_root       = "modules/sage-aws-eks-addons"
-      space_id           = "root"
-      version_number     = "0.2.0"
+      # branch             = var.git_branch
+      branch         = "ibcdpe-1007-manual-guardduty-install"
+      description    = "Terraform module for add-ons for an EKS cluster in AWS"
+      project_root   = "modules/sage-aws-eks-addons"
+      space_id       = "root"
+      version_number = "0.3.0"
     }
 
     victoria-metrics = {

--- a/modules/main.tf
+++ b/modules/main.tf
@@ -62,12 +62,11 @@ locals {
       name               = "sage-aws-eks-addons"
       terraform_provider = "aws"
       administrative     = false
-      # branch             = var.git_branch
-      branch         = "ibcdpe-1007-manual-guardduty-install"
-      description    = "Terraform module for add-ons for an EKS cluster in AWS"
-      project_root   = "modules/sage-aws-eks-addons"
-      space_id       = "root"
-      version_number = "0.3.0"
+      branch             = var.git_branch
+      description        = "Terraform module for add-ons for an EKS cluster in AWS"
+      project_root       = "modules/sage-aws-eks-addons"
+      space_id           = "root"
+      version_number     = "0.3.0"
     }
 
     victoria-metrics = {

--- a/modules/sage-aws-eks-addons/README.md
+++ b/modules/sage-aws-eks-addons/README.md
@@ -3,9 +3,9 @@ This module is responsible for installing any add ons or configuration elements 
 kubernetes cluster that require a node be added and running on the cluster.
 
 
-## installs
+## Installs
 
 - AWS Addon CoreDNS
 - AWS Addon EBS CSI Driver
 - Default storage class of GP3
-- AWS Guard duty - TODO (ibcdpe-1007)
+- AWS Guard duty + VPC Endpoint

--- a/modules/sage-aws-eks-addons/main.tf
+++ b/modules/sage-aws-eks-addons/main.tf
@@ -47,7 +47,7 @@ module "vpc-endpoints-guard-duty" {
   vpc_id     = var.vpc_id
 
   endpoints = {
-    guardduty = {
+    guardduty-data = {
       service = "com.amazonaws.us-east-1.guardduty-data"
       policy  = data.aws_iam_policy_document.restrict-vpc-endpoint-usage.json
       tags    = merge({ Name = "com.amazonaws.us-east-1.guardduty-data" }, var.tags)

--- a/modules/sage-aws-eks-addons/main.tf
+++ b/modules/sage-aws-eks-addons/main.tf
@@ -29,3 +29,66 @@ resource "kubernetes_storage_class" "default" {
   volume_binding_mode    = "WaitForFirstConsumer"
   allow_volume_expansion = true
 }
+
+# AWS Guard dity
+module "vpc-endpoints-guard-duty" {
+  source                = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
+  version               = "5.13.0"
+  create_security_group = true
+  security_group_name   = "vpc-endpoints-guard-duty-${var.cluster_name}"
+  security_group_rules = {
+    ingress_https = {
+      description = "HTTPS from VPC"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  }
+  subnet_ids = var.private_subnet_ids
+  tags       = var.tags
+  vpc_id     = var.vpc_id
+
+  endpoints = {
+    guardduty = {
+      service = "com.amazonaws.us-east-1.guardduty-data"
+      policy  = data.aws_iam_policy_document.restrict-vpc-endpoint-usage.json
+      tags    = merge({ Name = "com.amazonaws.us-east-1.guardduty-data" }, var.tags)
+    },
+  }
+
+}
+
+data "aws_iam_policy_document" "restrict-vpc-endpoint-usage" {
+  statement {
+    effect    = "Allow"
+    actions   = ["*"]
+    resources = ["*"]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
+
+  statement {
+    effect    = "Deny"
+    actions   = ["*"]
+    resources = ["*"]
+
+    condition {
+      test     = "StringNotEquals"
+      variable = "aws:Principal"
+      values   = [var.aws_account_id]
+    }
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
+}
+
+
+resource "aws_eks_addon" "aws-guardduty" {
+  cluster_name = var.cluster_name
+  addon_name   = "aws-guardduty-agent"
+  tags         = var.tags
+}

--- a/modules/sage-aws-eks-addons/main.tf
+++ b/modules/sage-aws-eks-addons/main.tf
@@ -48,9 +48,10 @@ module "vpc-endpoints-guard-duty" {
 
   endpoints = {
     guardduty-data = {
-      service = "com.amazonaws.us-east-1.guardduty-data"
-      policy  = data.aws_iam_policy_document.restrict-vpc-endpoint-usage.json
-      tags    = merge({ Name = "com.amazonaws.us-east-1.guardduty-data" }, var.tags)
+      service      = "com.amazonaws.us-east-1.guardduty-data"
+      service_name = "com.amazonaws.us-east-1.guardduty-data"
+      policy       = data.aws_iam_policy_document.restrict-vpc-endpoint-usage.json
+      tags         = merge({ Name = "com.amazonaws.us-east-1.guardduty-data" }, var.tags)
     },
   }
 

--- a/modules/sage-aws-eks-addons/main.tf
+++ b/modules/sage-aws-eks-addons/main.tf
@@ -30,7 +30,6 @@ resource "kubernetes_storage_class" "default" {
   allow_volume_expansion = true
 }
 
-# AWS Guard dity
 module "vpc-endpoints-guard-duty" {
   source                = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
   version               = "5.13.0"

--- a/modules/sage-aws-eks-addons/main.tf
+++ b/modules/sage-aws-eks-addons/main.tf
@@ -35,7 +35,6 @@ module "vpc-endpoints-guard-duty" {
   source                = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
   version               = "5.13.0"
   create_security_group = true
-  private_dns_enabled   = true
   security_group_name   = "vpc-endpoints-guard-duty-${var.cluster_name}"
   security_group_rules = {
     ingress_https = {
@@ -49,9 +48,10 @@ module "vpc-endpoints-guard-duty" {
 
   endpoints = {
     guardduty-data = {
-      service_name = "com.amazonaws.us-east-1.guardduty-data"
-      policy       = data.aws_iam_policy_document.restrict-vpc-endpoint-usage.json
-      tags         = merge({ Name = "com.amazonaws.us-east-1.guardduty-data" }, var.tags)
+      service_name        = "com.amazonaws.us-east-1.guardduty-data"
+      policy              = data.aws_iam_policy_document.restrict-vpc-endpoint-usage.json
+      private_dns_enabled = true
+      tags                = merge({ Name = "com.amazonaws.us-east-1.guardduty-data" }, var.tags)
     },
   }
 

--- a/modules/sage-aws-eks-addons/main.tf
+++ b/modules/sage-aws-eks-addons/main.tf
@@ -48,7 +48,6 @@ module "vpc-endpoints-guard-duty" {
 
   endpoints = {
     guardduty-data = {
-      service      = "com.amazonaws.us-east-1.guardduty-data"
       service_name = "com.amazonaws.us-east-1.guardduty-data"
       policy       = data.aws_iam_policy_document.restrict-vpc-endpoint-usage.json
       tags         = merge({ Name = "com.amazonaws.us-east-1.guardduty-data" }, var.tags)

--- a/modules/sage-aws-eks-addons/main.tf
+++ b/modules/sage-aws-eks-addons/main.tf
@@ -35,6 +35,7 @@ module "vpc-endpoints-guard-duty" {
   source                = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
   version               = "5.13.0"
   create_security_group = true
+  private_dns_enabled   = true
   security_group_name   = "vpc-endpoints-guard-duty-${var.cluster_name}"
   security_group_rules = {
     ingress_https = {

--- a/modules/sage-aws-eks-addons/variables.tf
+++ b/modules/sage-aws-eks-addons/variables.tf
@@ -12,3 +12,17 @@ variable "tags" {
   }
 }
 
+variable "aws_account_id" {
+  description = "AWS account ID"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "Private subnet IDs"
+  type        = list(string)
+}


### PR DESCRIPTION
**Problem:**

1. The automated install of AWS Guard duty added resources not managed by terraform and caused failures when tearing down the related infa.

**Solution:**

1. Implement: https://docs.aws.amazon.com/guardduty/latest/ug/managing-gdu-agent-eks-manually.html

**Testing:**

1. I tested the install of Guard Duty, and verified pods came up healthy. And we have healthy within the AWS Guard Duty console.