### PR TITLE
[IBCDPE-1004] Move back to celery executor

### DIFF
--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -469,7 +469,7 @@ kerberos:
 # Airflow Worker Config
 workers:
   # Number of airflow celery workers in StatefulSet
-  replicas: 1
+  replicas: 2
   # Max number of old replicasets to retain
   revisionHistoryLimit: ~
 
@@ -641,16 +641,16 @@ workers:
   nodeSelector: {}
   runtimeClassName: ~
   priorityClassName: ~
-  affinity: {}
+  affinity:
   # default worker affinity is:
-  #  podAntiAffinity:
-  #    preferredDuringSchedulingIgnoredDuringExecution:
-  #    - podAffinityTerm:
-  #        labelSelector:
-  #          matchLabels:
-  #            component: worker
-  #        topologyKey: kubernetes.io/hostname
-  #      weight: 100
+   podAntiAffinity:
+     preferredDuringSchedulingIgnoredDuringExecution:
+     - podAffinityTerm:
+         labelSelector:
+           matchLabels:
+             component: worker
+         topologyKey: kubernetes.io/hostname
+       weight: 100
   tolerations: []
   topologySpreadConstraints: []
   # hostAliases to use in worker pods.
@@ -723,7 +723,7 @@ scheduler:
     command: ~
   # Airflow 2.0 allows users to run multiple schedulers,
   # However this feature is only recommended for MySQL 8+ and Postgres
-  replicas: 1
+  replicas: 2
   # Max number of old replicasets to retain
   revisionHistoryLimit: ~
 
@@ -809,16 +809,16 @@ scheduler:
 
   # Select certain nodes for airflow scheduler pods.
   nodeSelector: {}
-  affinity: {}
+  affinity:
   # default scheduler affinity is:
-  #  podAntiAffinity:
-  #    preferredDuringSchedulingIgnoredDuringExecution:
-  #    - podAffinityTerm:
-  #        labelSelector:
-  #          matchLabels:
-  #            component: scheduler
-  #        topologyKey: kubernetes.io/hostname
-  #      weight: 100
+   podAntiAffinity:
+     preferredDuringSchedulingIgnoredDuringExecution:
+     - podAffinityTerm:
+         labelSelector:
+           matchLabels:
+             component: scheduler
+         topologyKey: kubernetes.io/hostname
+       weight: 100
   tolerations: []
   topologySpreadConstraints: []
 
@@ -1250,7 +1250,7 @@ webserver:
 triggerer:
   enabled: true
   # Number of airflow triggerers in the deployment
-  replicas: 1
+  replicas: 2
   # Max number of old replicasets to retain
   revisionHistoryLimit: ~
 
@@ -1351,16 +1351,16 @@ triggerer:
 
   # Select certain nodes for airflow triggerer pods.
   nodeSelector: {}
-  affinity: {}
+  affinity:
   # default triggerer affinity is:
-  #  podAntiAffinity:
-  #    preferredDuringSchedulingIgnoredDuringExecution:
-  #    - podAffinityTerm:
-  #        labelSelector:
-  #          matchLabels:
-  #            component: triggerer
-  #        topologyKey: kubernetes.io/hostname
-  #      weight: 100
+   podAntiAffinity:
+     preferredDuringSchedulingIgnoredDuringExecution:
+     - podAffinityTerm:
+         labelSelector:
+           matchLabels:
+             component: triggerer
+         topologyKey: kubernetes.io/hostname
+       weight: 100
   tolerations: []
   topologySpreadConstraints: []
 
@@ -1661,7 +1661,7 @@ flower:
 
 # StatsD settings
 statsd:
-  enabled: true
+  enabled: false
   # Max number of old replicasets to retain
   revisionHistoryLimit: ~
 

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -241,7 +241,7 @@ rbac:
 
 # Airflow executor
 # One of: LocalExecutor, LocalKubernetesExecutor, CeleryExecutor, KubernetesExecutor, CeleryKubernetesExecutor
-executor: "KubernetesExecutor"
+executor: "CeleryExecutor"
 
 # If this is true and using LocalExecutor/KubernetesExecutor/CeleryKubernetesExecutor, the scheduler's
 # service account will have access to communicate with the api-server and launch pods.

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -2010,7 +2010,7 @@ limits: []
 
 # This runs as a CronJob to cleanup old pods.
 cleanup:
-  enabled: true
+  enabled: false
   # Run every 15 minutes (templated).
   schedule: "*/60 * * * *"
   # To select a random-ish, deterministic starting minute between 3 and 12 inclusive for each release:

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -2012,7 +2012,7 @@ limits: []
 cleanup:
   enabled: true
   # Run every 15 minutes (templated).
-  schedule: "*/15 * * * *"
+  schedule: "*/60 * * * *"
   # To select a random-ish, deterministic starting minute between 3 and 12 inclusive for each release:
   #     '{{- add 3 (regexFind ".$" (adler32sum .Release.Name)) -}}-59/15 * * * *'
   # To select the last digit of unix epoch time as the starting minute on each deploy:


### PR DESCRIPTION
**Problem:**

1. Usage of the kubernetes executor requires setting up a remote write solution to write logs to (Like S3).
2. Because of the volatile nature of running the cluster on spot instances I was seeing that components of airflow were going down because the node was taken out of the cluster.

**Solution:**

1. Fall back to celery executor.
2. Bump replicas up for core airflow components to allow scheduling, and running of tasks in high availability. The pod anti affinity should also cause the pods to be scheduled on different nodes, giving up more uptime.

**Testing:**

1. I verified this on the sandbox cluster:
![image](https://github.com/user-attachments/assets/7de2cd2f-9568-4a15-8d2b-876652aacc17)

![image](https://github.com/user-attachments/assets/f48bf069-9016-4576-8207-ef594fd6b3c6)


