### PR TITLE
[IBCDPE-1004] Set env for class deserialization

### DIFF
--- a/modules/apache-airflow/README.md
+++ b/modules/apache-airflow/README.md
@@ -1,6 +1,13 @@
 # Purpose
 The purpose of this module is to deploy the `Apache Airflow` helm chart <https://github.com/apache/airflow/tree/main/chart>.
 
+## WARNING
+**When upgrading the apache airflow instance that is deployed to kubernetes you will need
+to manually kill the `airflow-redis` pod.** Why? There is a helm hook that set the
+password to connect to `redis` when helm sees a change, however, the `redis` pod is not
+automatically restarted. If you do not do this change all airflow components that
+connect to the `redis` pod will be connecting with a new password, but `redis` is still
+expecting the old password.
 
 ## What resources are being deployed through this module
 

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -1055,14 +1055,14 @@ webserver:
   #      - "foo.remote"
   allowPodLogReading: true
   livenessProbe:
-    initialDelaySeconds: 60
+    initialDelaySeconds: 120
     timeoutSeconds: 5
     failureThreshold: 5
     periodSeconds: 10
     scheme: HTTP
 
   readinessProbe:
-    initialDelaySeconds: 60
+    initialDelaySeconds: 120
     timeoutSeconds: 5
     failureThreshold: 5
     periodSeconds: 10
@@ -2153,6 +2153,10 @@ config:
     worker_container_repository: '{{ .Values.images.airflow.repository | default .Values.defaultAirflowRepository }}'
     worker_container_tag: '{{ .Values.images.airflow.tag | default .Values.defaultAirflowTag }}'
     multi_namespace_mode: '{{ ternary "True" "False" .Values.multiNamespaceMode }}'
+    git_repo: 'https://github.com/Sage-Bionetworks-Workflows/orca-recipes'
+    git_branch: 'test-deserialization'
+    git_subpath: 'dags'
+    git_sync_rev: 'HEAD'
   # The `kubernetes_executor` section duplicates the `kubernetes` section in Airflow >= 2.5.0 due to an airflow.cfg schema change.
   kubernetes_executor:
     namespace: '{{ .Release.Namespace }}'

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -2218,7 +2218,7 @@ dags:
     # ssh example: git@github.com:apache/airflow.git
     # https example: https://github.com/apache/airflow.git
     repo: https://github.com/Sage-Bionetworks-Workflows/orca-recipes
-    branch: main
+    branch: test-deserialization
     rev: HEAD
     depth: 1
     # the number of consecutive failures allowed before aborting

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -486,7 +486,7 @@ workers:
   # worker and let Kubernetes restart it
   livenessProbe:
     enabled: true
-    initialDelaySeconds: 10
+    initialDelaySeconds: 60
     timeoutSeconds: 20
     failureThreshold: 5
     periodSeconds: 60
@@ -714,7 +714,7 @@ scheduler:
   # If the scheduler stops heartbeating for 5 minutes (5*60s) kill the
   # scheduler and let Kubernetes restart it
   livenessProbe:
-    initialDelaySeconds: 10
+    initialDelaySeconds: 60
     timeoutSeconds: 20
     failureThreshold: 5
     periodSeconds: 60
@@ -1055,14 +1055,14 @@ webserver:
   #      - "foo.remote"
   allowPodLogReading: true
   livenessProbe:
-    initialDelaySeconds: 15
+    initialDelaySeconds: 60
     timeoutSeconds: 5
     failureThreshold: 5
     periodSeconds: 10
     scheme: HTTP
 
   readinessProbe:
-    initialDelaySeconds: 15
+    initialDelaySeconds: 60
     timeoutSeconds: 5
     failureThreshold: 5
     periodSeconds: 10
@@ -1268,7 +1268,7 @@ triggerer:
   # If the triggerer stops heartbeating for 5 minutes (5*60s) kill the
   # triggerer and let Kubernetes restart it
   livenessProbe:
-    initialDelaySeconds: 10
+    initialDelaySeconds: 60
     timeoutSeconds: 20
     failureThreshold: 5
     periodSeconds: 60

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -250,9 +250,7 @@ executor: "CeleryExecutor"
 allowPodLaunching: true
 
 # Environment variables for all airflow containers
-env:
-- name: "AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES"
-  value: "airflow.* DownloadMetric SnapshotMetrics LENSDataset Dataset Syn.*"
+env: []
 
 # Volumes for all airflow containers
 volumes: []
@@ -2105,6 +2103,7 @@ config:
     # For Airflow 1.10, backward compatibility; moved to [logging] in 2.0
     colored_console_log: 'False'
     remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
+    allowed_deserialization_classes: "airflow.* DownloadMetric SnapshotMetrics LENSDataset Dataset Syn.*"
   logging:
     remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
     colored_console_log: 'False'

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -2218,7 +2218,7 @@ dags:
     # ssh example: git@github.com:apache/airflow.git
     # https example: https://github.com/apache/airflow.git
     repo: https://github.com/Sage-Bionetworks-Workflows/orca-recipes
-    branch: test-deserialization
+    branch: main
     rev: HEAD
     depth: 1
     # the number of consecutive failures allowed before aborting

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -2153,10 +2153,6 @@ config:
     worker_container_repository: '{{ .Values.images.airflow.repository | default .Values.defaultAirflowRepository }}'
     worker_container_tag: '{{ .Values.images.airflow.tag | default .Values.defaultAirflowTag }}'
     multi_namespace_mode: '{{ ternary "True" "False" .Values.multiNamespaceMode }}'
-    git_repo: 'https://github.com/Sage-Bionetworks-Workflows/orca-recipes'
-    git_branch: 'test-deserialization'
-    git_subpath: 'dags'
-    git_sync_rev: 'HEAD'
   # The `kubernetes_executor` section duplicates the `kubernetes` section in Airflow >= 2.5.0 due to an airflow.cfg schema change.
   kubernetes_executor:
     namespace: '{{ .Release.Namespace }}'

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -250,9 +250,9 @@ executor: "CeleryExecutor"
 allowPodLaunching: true
 
 # Environment variables for all airflow containers
-env: []
-# - name: ""
-#   value: ""
+env:
+- name: "AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES"
+  value: "airflow.* DownloadMetric SnapshotMetrics LENSDataset Dataset Syn.*"
 
 # Volumes for all airflow containers
 volumes: []

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -2103,7 +2103,7 @@ config:
     # For Airflow 1.10, backward compatibility; moved to [logging] in 2.0
     colored_console_log: 'False'
     remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
-    allowed_deserialization_classes: "airflow.* DownloadMetric SnapshotMetrics LENSDataset Dataset Syn.*"
+    allowed_deserialization_classes: "*"
   logging:
     remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
     colored_console_log: 'False'
@@ -2264,7 +2264,7 @@ dags:
     # interval between git sync attempts in seconds
     # high values are more likely to cause DAGs to become out of sync between different components
     # low values cause more traffic to the remote git repository
-    wait: 5
+    wait: 60
     containerName: git-sync
     uid: 65533
 

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -2103,7 +2103,7 @@ config:
     # For Airflow 1.10, backward compatibility; moved to [logging] in 2.0
     colored_console_log: 'False'
     remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
-    allowed_deserialization_classes: "*"
+    allowed_deserialization_classes: ".*"
   logging:
     remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
     colored_console_log: 'False'
@@ -2264,7 +2264,7 @@ dags:
     # interval between git sync attempts in seconds
     # high values are more likely to cause DAGs to become out of sync between different components
     # low values cause more traffic to the remote git repository
-    wait: 60
+    wait: 600
     containerName: git-sync
     uid: 65533
 


### PR DESCRIPTION
**Problem:**

1. `ImportError: unusual_prefix_b22621ef2028bf7db4581afeff23e3f182d62fc3_trending-projects-snapshot-dag.SnapshotMetrics was not found in allow list for deserialization imports. To allow it, add it to allowed_deserialization_classes in the configuration`
2. All of the classes that are passed around are not explicitly allowed, running into this error.

**Solution:**

1. Adding an environment variable that is supposed to allow this to allow anything so we don't need to go in and re-deploy airflow.

**Testing:**

1. Verified after deploying changes that the content is making it through by testing this dag: https://github.com/Sage-Bionetworks-Workflows/orca-recipes/blob/test-deserialization/dags/testing-deserialization.py

![image](https://github.com/user-attachments/assets/fde42349-0e37-4083-bf9a-ceeed691c7d4)
