### PR TITLE
[IBCDPE-1004] Pull back to single AZ

### DIFF
--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -37,10 +37,16 @@ module "dpe-sandbox-spacelift-development" {
   cluster_name = "dpe-k8-sandbox"
   vpc_name     = "dpe-sandbox"
 
-  vpc_cidr_block       = "10.51.0.0/16"
-  public_subnet_cidrs  = ["10.51.1.0/24", "10.51.2.0/24", "10.51.3.0/24"]
-  private_subnet_cidrs = ["10.51.4.0/24", "10.51.5.0/24", "10.51.6.0/24"]
-  azs                  = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  vpc_cidr_block = "10.51.0.0/16"
+  # public_subnet_cidrs  = ["10.51.1.0/24", "10.51.2.0/24", "10.51.3.0/24"]
+  # private_subnet_cidrs = ["10.51.4.0/24", "10.51.5.0/24", "10.51.6.0/24"]
+  # azs                  = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  # For now, we are only using one public and one private subnet. This is due to how
+  # EBS can only be mounted to a single AZ. We will need to revisit this if we want to
+  # allow usage of EFS ($$$$), or add some kind of EBS volume replication.
+  public_subnet_cidrs  = ["10.51.1.0/24"]
+  private_subnet_cidrs = ["10.51.4.0/24"]
+  azs                  = ["us-east-1a"]
 }
 
 module "dpe-sandbox-spacelift-production" {
@@ -67,8 +73,14 @@ module "dpe-sandbox-spacelift-production" {
   cluster_name = "dpe-k8"
   vpc_name     = "dpe-k8"
 
-  vpc_cidr_block       = "10.52.0.0/16"
-  public_subnet_cidrs  = ["10.52.1.0/24", "10.52.2.0/24", "10.52.3.0/24"]
-  private_subnet_cidrs = ["10.52.4.0/24", "10.52.5.0/24", "10.52.6.0/24"]
-  azs                  = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  vpc_cidr_block = "10.52.0.0/16"
+  # public_subnet_cidrs  = ["10.52.1.0/24", "10.52.2.0/24", "10.52.3.0/24"]
+  # private_subnet_cidrs = ["10.52.4.0/24", "10.52.5.0/24", "10.52.6.0/24"]
+  # azs                  = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  # For now, we are only using one public and one private subnet. This is due to how
+  # EBS can only be mounted to a single AZ. We will need to revisit this if we want to
+  # allow usage of EFS ($$$$), or add some kind of EBS volume replication.
+  public_subnet_cidrs  = ["10.52.1.0/24"]
+  private_subnet_cidrs = ["10.52.4.0/24"]
+  azs                  = ["us-east-1a"]
 }

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -571,7 +571,7 @@ workers:
     # Enable persistent volumes
     enabled: true
     # Volume size for worker StatefulSet
-    size: 100Gi
+    size: 30Gi
     # If using a custom storageClass, pass name ref to all statefulSets here
     storageClassName:
     # Execute init container to chown log directory.
@@ -1302,7 +1302,7 @@ triggerer:
     # Enable persistent volumes
     enabled: true
     # Volume size for triggerer StatefulSet
-    size: 100Gi
+    size: 30Gi
     # If using a custom storageClass, pass name ref to all statefulSets here
     storageClassName:
     # Execute init container to chown log directory.
@@ -2300,7 +2300,7 @@ logs:
     # Enable persistent volume for storing logs
     enabled: false
     # Volume size for logs
-    size: 50Gi
+    size: 30Gi
     # Annotations for the logs PVC
     annotations: {}
     # If using a custom storageClass, pass name here

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -639,16 +639,16 @@ workers:
   nodeSelector: {}
   runtimeClassName: ~
   priorityClassName: ~
-  affinity: {}
+  affinity:
   # default worker affinity is:
-  #  podAntiAffinity:
-  #    preferredDuringSchedulingIgnoredDuringExecution:
-  #    - podAffinityTerm:
-  #        labelSelector:
-  #          matchLabels:
-  #            component: worker
-  #        topologyKey: kubernetes.io/hostname
-  #      weight: 100
+   podAntiAffinity:
+     preferredDuringSchedulingIgnoredDuringExecution:
+     - podAffinityTerm:
+         labelSelector:
+           matchLabels:
+             component: worker
+         topologyKey: kubernetes.io/hostname
+       weight: 100
   tolerations: []
   topologySpreadConstraints: []
   # hostAliases to use in worker pods.
@@ -807,16 +807,16 @@ scheduler:
 
   # Select certain nodes for airflow scheduler pods.
   nodeSelector: {}
-  affinity: {}
+  affinity:
   # default scheduler affinity is:
-  #  podAntiAffinity:
-  #    preferredDuringSchedulingIgnoredDuringExecution:
-  #    - podAffinityTerm:
-  #        labelSelector:
-  #          matchLabels:
-  #            component: scheduler
-  #        topologyKey: kubernetes.io/hostname
-  #      weight: 100
+   podAntiAffinity:
+     preferredDuringSchedulingIgnoredDuringExecution:
+     - podAffinityTerm:
+         labelSelector:
+           matchLabels:
+             component: scheduler
+         topologyKey: kubernetes.io/hostname
+       weight: 100
   tolerations: []
   topologySpreadConstraints: []
 
@@ -1349,16 +1349,16 @@ triggerer:
 
   # Select certain nodes for airflow triggerer pods.
   nodeSelector: {}
-  affinity: {}
+  affinity:
   # default triggerer affinity is:
-  #  podAntiAffinity:
-  #    preferredDuringSchedulingIgnoredDuringExecution:
-  #    - podAffinityTerm:
-  #        labelSelector:
-  #          matchLabels:
-  #            component: triggerer
-  #        topologyKey: kubernetes.io/hostname
-  #      weight: 100
+   podAntiAffinity:
+     preferredDuringSchedulingIgnoredDuringExecution:
+     - podAffinityTerm:
+         labelSelector:
+           matchLabels:
+             component: triggerer
+         topologyKey: kubernetes.io/hostname
+       weight: 100
   tolerations: []
   topologySpreadConstraints: []
 


### PR DESCRIPTION
**Problem:**

1. EBS volumes being used for mounted storage within the EKS cluster can only be re-mounted in the same AZ that it was created in. This is a problem as Spot IO when it provisions new nodes for the clusters does not use this context to know when to provision another cluster in the appropriate AZ. This leads to pods being stuck in pending and not scheduled.

**Solution:**

1. Fall back to a single AZ for now. Later on we'll determine a more robust solution to span AZs for High availability.