### PR TITLE
Add trigger-always on dependency reference

### DIFF
--- a/deployments/spacelift/dpe-k8s/main.tf
+++ b/deployments/spacelift/dpe-k8s/main.tf
@@ -139,6 +139,8 @@ resource "spacelift_stack_dependency_reference" "dependency-references" {
   stack_dependency_id = spacelift_stack_dependency.k8s-stack-to-deployments.id
   output_name         = each.key
   input_name          = each.value
+  # See https://github.com/spacelift-io/terraform-provider-spacelift/issues/565
+  trigger_always = true
 }
 
 resource "spacelift_stack_dependency_reference" "region-name" {


### PR DESCRIPTION
**Problem:**

1. See description on https://github.com/spacelift-io/terraform-provider-spacelift/issues/565

**Solution:**

1. Add trigger_always so that even if a value of a variable being passed along did not change, the dependent stack will still run. This is to fix some issues that @BWMac identified early on when we were incrementing a module version in both the `modules/*` directory, and updating it's usage in `deployments/stacks/*`. We previously needed to run this in 2 commits, 1st commit was to get the admin stack to run, 2nd commit was to use the new module version in the deployment.

**Testing:**

1. Adding this now and will verify the next time we have a module version update to do.