### PR TITLE
Moving airflow to on-demand

### DIFF
--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -108,7 +108,9 @@ images:
     pullPolicy: IfNotPresent
 
 # Select certain nodes for airflow pods.
-nodeSelector: {}
+nodeSelector: {
+  topology.kubernetes.io/zone: us-east-1a
+}
 affinity: {}
 tolerations: []
 topologySpreadConstraints: []
@@ -467,7 +469,7 @@ kerberos:
 # Airflow Worker Config
 workers:
   # Number of airflow celery workers in StatefulSet
-  replicas: 2
+  replicas: 1
   # Max number of old replicasets to retain
   revisionHistoryLimit: ~
 
@@ -636,7 +638,9 @@ workers:
   extraVolumeMounts: []
 
   # Select certain nodes for airflow worker pods.
-  nodeSelector: {}
+  nodeSelector: {
+    spotinst.io/node-lifecycle: "od"
+  }
   runtimeClassName: ~
   priorityClassName: ~
   affinity:
@@ -721,7 +725,7 @@ scheduler:
     command: ~
   # Airflow 2.0 allows users to run multiple schedulers,
   # However this feature is only recommended for MySQL 8+ and Postgres
-  replicas: 2
+  replicas: 1
   # Max number of old replicasets to retain
   revisionHistoryLimit: ~
 
@@ -806,7 +810,9 @@ scheduler:
   extraVolumeMounts: []
 
   # Select certain nodes for airflow scheduler pods.
-  nodeSelector: {}
+  nodeSelector: {
+    spotinst.io/node-lifecycle: "od"
+  }
   affinity:
   # default scheduler affinity is:
    podAntiAffinity:
@@ -1248,7 +1254,7 @@ webserver:
 triggerer:
   enabled: true
   # Number of airflow triggerers in the deployment
-  replicas: 2
+  replicas: 1
   # Max number of old replicasets to retain
   revisionHistoryLimit: ~
 
@@ -1348,7 +1354,9 @@ triggerer:
   extraVolumeMounts: []
 
   # Select certain nodes for airflow triggerer pods.
-  nodeSelector: {}
+  nodeSelector: {
+    spotinst.io/node-lifecycle: "od"
+  }
   affinity:
   # default triggerer affinity is:
    podAntiAffinity:
@@ -1942,7 +1950,9 @@ redis:
   safeToEvict: true
 
   # Select certain nodes for redis pods.
-  nodeSelector: {}
+  nodeSelector: {
+    spotinst.io/node-lifecycle: "od"
+  }
   affinity: {}
   tolerations: []
   topologySpreadConstraints: []


### PR DESCRIPTION
**Problem:**

1. Redis goes down after around a month because the persistent volume gets deleted. My suspicion is that something is occurring with the spot instances that is causing issues.

**Solution:**

1. Move several pods to on-demand instances instead of spot instances to make sure they have sufficient up-time always, and prevent any issues with persistent volumes from detaching.

**Testing:**

1. Will be verifying in dev before applying to prod.