### PR TITLE
[IBCDPE-1097] Shrink vpc subnets and move worker nodes

### DIFF
--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -37,10 +37,13 @@ module "dpe-sandbox-spacelift-development" {
   cluster_name = "dpe-k8-sandbox"
   vpc_name     = "dpe-sandbox"
 
-  vpc_cidr_block       = "10.51.0.0/16"
-  public_subnet_cidrs  = ["10.51.1.0/24", "10.51.2.0/24"]
-  private_subnet_cidrs = ["10.51.4.0/24", "10.51.5.0/24"]
-  azs                  = ["us-east-1a", "us-east-1b"]
+  vpc_cidr_block                         = "10.52.16.0/20"
+  public_subnet_cidrs                    = ["10.52.16.0/24", "10.52.17.0/24"]
+  private_subnet_cidrs_eks_control_plane = ["10.52.18.0/24", "10.52.19.0/24"]
+  azs_eks_control_plane                  = ["us-east-1a", "us-east-1b"]
+
+  private_subnet_cidrs_eks_worker_nodes = ["10.52.20.0/22", "10.52.24.0/22", "10.52.26.0/22"]
+  azs_eks_worker_nodes                  = ["us-east-1a", "us-east-1b", "us-east-1c"]
 }
 
 module "dpe-sandbox-spacelift-production" {
@@ -67,8 +70,11 @@ module "dpe-sandbox-spacelift-production" {
   cluster_name = "dpe-k8"
   vpc_name     = "dpe-k8"
 
-  vpc_cidr_block       = "10.52.0.0/16"
-  public_subnet_cidrs  = ["10.52.1.0/24", "10.52.2.0/24"]
-  private_subnet_cidrs = ["10.52.4.0/24", "10.52.5.0/24"]
-  azs                  = ["us-east-1a", "us-east-1b"]
+  vpc_cidr_block                         = "10.52.0.0/20"
+  public_subnet_cidrs                    = ["10.52.1.0/24", "10.52.2.0/24"]
+  private_subnet_cidrs_eks_control_plane = ["10.52.4.0/24", "10.52.5.0/24"]
+  azs_eks_control_plane                  = ["us-east-1a", "us-east-1b"]
+
+  private_subnet_cidrs_eks_worker_nodes = ["10.52.6.0/22", "10.52.10.0/22", "10.52.14.0/22"]
+  azs_eks_worker_nodes                  = ["us-east-1a", "us-east-1b", "us-east-1c"]
 }

--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -71,10 +71,10 @@ module "dpe-sandbox-spacelift-production" {
   vpc_name     = "dpe-k8"
 
   vpc_cidr_block                         = "10.52.0.0/20"
-  public_subnet_cidrs                    = ["10.52.1.0/24", "10.52.2.0/24"]
-  private_subnet_cidrs_eks_control_plane = ["10.52.4.0/24", "10.52.5.0/24"]
+  public_subnet_cidrs                    = ["10.52.0.0/24", "10.52.1.0/24"]
+  private_subnet_cidrs_eks_control_plane = ["10.52.2.0/24", "10.52.3.0/24"]
   azs_eks_control_plane                  = ["us-east-1a", "us-east-1b"]
 
-  private_subnet_cidrs_eks_worker_nodes = ["10.52.6.0/22", "10.52.10.0/22", "10.52.14.0/22"]
+  private_subnet_cidrs_eks_worker_nodes = ["10.52.4.0/22", "10.52.8.0/22", "10.52.12.0/22"]
   azs_eks_worker_nodes                  = ["us-east-1a", "us-east-1b", "us-east-1c"]
 }

--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -42,7 +42,7 @@ module "dpe-sandbox-spacelift-development" {
   private_subnet_cidrs_eks_control_plane = ["10.52.18.0/24", "10.52.19.0/24"]
   azs_eks_control_plane                  = ["us-east-1a", "us-east-1b"]
 
-  private_subnet_cidrs_eks_worker_nodes = ["10.52.20.0/22", "10.52.24.0/22", "10.52.26.0/22"]
+  private_subnet_cidrs_eks_worker_nodes = ["10.52.20.0/22", "10.52.24.0/22", "10.52.28.0/22"]
   azs_eks_worker_nodes                  = ["us-east-1a", "us-east-1b", "us-east-1c"]
 }
 

--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -37,13 +37,12 @@ module "dpe-sandbox-spacelift-development" {
   cluster_name = "dpe-k8-sandbox"
   vpc_name     = "dpe-sandbox"
 
-  vpc_cidr_block      = "10.52.16.0/20"
-  public_subnet_cidrs = ["10.52.16.0/24", "10.52.17.0/24"]
-  # 10.52.18.32 -> 10.52.19.0 is free for future use
+  vpc_cidr_block                         = "10.52.16.0/20"
+  public_subnet_cidrs                    = ["10.52.16.0/24", "10.52.17.0/24"]
   private_subnet_cidrs_eks_control_plane = ["10.52.18.0/28", "10.52.18.16/28"]
   azs_eks_control_plane                  = ["us-east-1a", "us-east-1b"]
 
-  private_subnet_cidrs_eks_worker_nodes = ["10.52.19.0/22", "10.52.23.0/22", "10.52.27.0/22"]
+  private_subnet_cidrs_eks_worker_nodes = ["10.52.20.0/22", "10.52.24.0/22", "10.52.28.0/22"]
   azs_eks_worker_nodes                  = ["us-east-1a", "us-east-1b", "us-east-1c"]
 }
 
@@ -71,12 +70,11 @@ module "dpe-sandbox-spacelift-production" {
   cluster_name = "dpe-k8"
   vpc_name     = "dpe-k8"
 
-  vpc_cidr_block      = "10.52.0.0/20"
-  public_subnet_cidrs = ["10.52.0.0/24", "10.52.1.0/24"]
-  # 10.52.2.32 -> 10.52.3.0 is free for future use
+  vpc_cidr_block                         = "10.52.0.0/20"
+  public_subnet_cidrs                    = ["10.52.0.0/24", "10.52.1.0/24"]
   private_subnet_cidrs_eks_control_plane = ["10.52.2.0/28", "10.52.2.16/28"]
   azs_eks_control_plane                  = ["us-east-1a", "us-east-1b"]
 
-  private_subnet_cidrs_eks_worker_nodes = ["10.52.3.0/22", "10.52.7.0/22", "10.52.11.0/22"]
+  private_subnet_cidrs_eks_worker_nodes = ["10.52.4.0/22", "10.52.8.0/22", "10.52.12.0/22"]
   azs_eks_worker_nodes                  = ["us-east-1a", "us-east-1b", "us-east-1c"]
 }

--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -37,12 +37,13 @@ module "dpe-sandbox-spacelift-development" {
   cluster_name = "dpe-k8-sandbox"
   vpc_name     = "dpe-sandbox"
 
-  vpc_cidr_block                         = "10.52.16.0/20"
-  public_subnet_cidrs                    = ["10.52.16.0/24", "10.52.17.0/24"]
-  private_subnet_cidrs_eks_control_plane = ["10.52.18.0/24", "10.52.19.0/24"]
+  vpc_cidr_block      = "10.52.16.0/20"
+  public_subnet_cidrs = ["10.52.16.0/24", "10.52.17.0/24"]
+  # 10.52.18.32 -> 10.52.19.0 is free for future use
+  private_subnet_cidrs_eks_control_plane = ["10.52.18.0/28", "10.52.18.16/28"]
   azs_eks_control_plane                  = ["us-east-1a", "us-east-1b"]
 
-  private_subnet_cidrs_eks_worker_nodes = ["10.52.20.0/22", "10.52.24.0/22", "10.52.28.0/22"]
+  private_subnet_cidrs_eks_worker_nodes = ["10.52.19.0/22", "10.52.23.0/22", "10.52.27.0/22"]
   azs_eks_worker_nodes                  = ["us-east-1a", "us-east-1b", "us-east-1c"]
 }
 
@@ -70,11 +71,12 @@ module "dpe-sandbox-spacelift-production" {
   cluster_name = "dpe-k8"
   vpc_name     = "dpe-k8"
 
-  vpc_cidr_block                         = "10.52.0.0/20"
-  public_subnet_cidrs                    = ["10.52.0.0/24", "10.52.1.0/24"]
-  private_subnet_cidrs_eks_control_plane = ["10.52.2.0/24", "10.52.3.0/24"]
+  vpc_cidr_block      = "10.52.0.0/20"
+  public_subnet_cidrs = ["10.52.0.0/24", "10.52.1.0/24"]
+  # 10.52.2.32 -> 10.52.3.0 is free for future use
+  private_subnet_cidrs_eks_control_plane = ["10.52.2.0/28", "10.52.2.16/28"]
   azs_eks_control_plane                  = ["us-east-1a", "us-east-1b"]
 
-  private_subnet_cidrs_eks_worker_nodes = ["10.52.4.0/22", "10.52.8.0/22", "10.52.12.0/22"]
+  private_subnet_cidrs_eks_worker_nodes = ["10.52.3.0/22", "10.52.7.0/22", "10.52.11.0/22"]
   azs_eks_worker_nodes                  = ["us-east-1a", "us-east-1b", "us-east-1c"]
 }

--- a/deployments/spacelift/dpe-k8s/main.tf
+++ b/deployments/spacelift/dpe-k8s/main.tf
@@ -1,14 +1,16 @@
 locals {
   k8s_stack_environment_variables = {
-    aws_account_id                    = var.aws_account_id
-    region                            = var.region
-    pod_security_group_enforcing_mode = var.pod_security_group_enforcing_mode
-    cluster_name                      = var.cluster_name
-    vpc_name                          = var.vpc_name
-    vpc_cidr_block                    = var.vpc_cidr_block
-    public_subnet_cidrs               = var.public_subnet_cidrs
-    private_subnet_cidrs              = var.private_subnet_cidrs
-    azs                               = var.azs
+    aws_account_id                         = var.aws_account_id
+    region                                 = var.region
+    pod_security_group_enforcing_mode      = var.pod_security_group_enforcing_mode
+    cluster_name                           = var.cluster_name
+    vpc_name                               = var.vpc_name
+    vpc_cidr_block                         = var.vpc_cidr_block
+    public_subnet_cidrs                    = var.public_subnet_cidrs
+    private_subnet_cidrs_eks_control_plane = var.private_subnet_cidrs_eks_control_plane
+    private_subnet_cidrs_eks_worker_nodes  = var.private_subnet_cidrs_eks_worker_nodes
+    azs_eks_control_plane                  = var.azs_eks_control_plane
+    azs_eks_worker_nodes                   = var.azs_eks_worker_nodes
   }
 
   k8s_stack_deployments_variables = {
@@ -23,10 +25,10 @@ locals {
 
   # Variables to be passed from the k8s stack to the deployments stack
   k8s_stack_to_deployment_variables = {
-    vpc_id                 = "TF_VAR_vpc_id"
-    private_subnet_ids     = "TF_VAR_private_subnet_ids"
-    node_security_group_id = "TF_VAR_node_security_group_id"
-    pod_to_node_dns_sg_id  = "TF_VAR_pod_to_node_dns_sg_id"
+    vpc_id                              = "TF_VAR_vpc_id"
+    private_subnet_ids_eks_worker_nodes = "TF_VAR_private_subnet_ids_eks_worker_nodes"
+    node_security_group_id              = "TF_VAR_node_security_group_id"
+    pod_to_node_dns_sg_id               = "TF_VAR_pod_to_node_dns_sg_id"
   }
 }
 

--- a/deployments/spacelift/dpe-k8s/variables.tf
+++ b/deployments/spacelift/dpe-k8s/variables.tf
@@ -118,12 +118,22 @@ variable "public_subnet_cidrs" {
   description = "Public Subnet CIDR values"
 }
 
-variable "private_subnet_cidrs" {
+variable "private_subnet_cidrs_eks_control_plane" {
   type        = list(string)
-  description = "Private Subnet CIDR values"
+  description = "Private Subnet CIDR values for the EKS control plane"
 }
 
-variable "azs" {
+variable "private_subnet_cidrs_eks_worker_nodes" {
   type        = list(string)
-  description = "Availability Zones"
+  description = "Private Subnet CIDR values for the EKS worker nodes"
+}
+
+variable "azs_eks_control_plane" {
+  type        = list(string)
+  description = "Availability Zones for the EKS control plane"
+}
+
+variable "azs_eks_worker_nodes" {
+  type        = list(string)
+  description = "Availability Zones for the EKS worker nodes"
 }

--- a/deployments/stacks/dpe-k8s-deployments/main.tf
+++ b/deployments/stacks/dpe-k8s-deployments/main.tf
@@ -2,7 +2,7 @@ module "sage-aws-eks-autoscaler" {
   source                 = "spacelift.io/sagebionetworks/sage-aws-eks-autoscaler/aws"
   version                = "0.9.0"
   cluster_name           = var.cluster_name
-  private_vpc_subnet_ids = var.private_subnet_ids
+  private_vpc_subnet_ids = var.private_subnet_ids_eks_worker_nodes
   vpc_id                 = var.vpc_id
   node_security_group_id = var.node_security_group_id
   spotinst_account       = var.spotinst_account
@@ -16,7 +16,7 @@ module "sage-aws-eks-addons" {
   cluster_name       = var.cluster_name
   aws_account_id     = var.aws_account_id
   vpc_id             = var.vpc_id
-  private_subnet_ids = var.private_subnet_ids
+  private_subnet_ids = var.private_subnet_ids_eks_worker_nodes
 }
 
 module "argo-cd" {

--- a/deployments/stacks/dpe-k8s-deployments/variables.tf
+++ b/deployments/stacks/dpe-k8s-deployments/variables.tf
@@ -3,8 +3,8 @@ variable "vpc_id" {
   type        = string
 }
 
-variable "private_subnet_ids" {
-  description = "Private subnet IDs"
+variable "private_subnet_ids_eks_worker_nodes" {
+  description = "Private subnet IDs for the EKS worker nodes"
   type        = list(string)
 }
 

--- a/deployments/stacks/dpe-k8s/main.tf
+++ b/deployments/stacks/dpe-k8s/main.tf
@@ -1,24 +1,27 @@
 module "sage-aws-vpc" {
-  source   = "spacelift.io/sagebionetworks/sage-aws-vpc/aws"
-  version  = "0.4.2"
+  # source   = "spacelift.io/sagebionetworks/sage-aws-vpc/aws"
+  # version  = "0.4.2"
+  source   = "../../../modules/sage-aws-vpc"
   vpc_name = var.vpc_name
   # TODO: Per https://sagebionetworks.jira.com/browse/IT-3824
   # We will soon not have to capture the VPC flow logs outself as every account with a VPC will have them enabled by default
-  capture_flow_logs    = true
-  flow_log_retention   = 90
-  vpc_cidr_block       = var.vpc_cidr_block
-  public_subnet_cidrs  = var.public_subnet_cidrs
-  private_subnet_cidrs = var.private_subnet_cidrs
-  azs                  = var.azs
-  region               = var.region
+  capture_flow_logs                      = true
+  flow_log_retention                     = 90
+  vpc_cidr_block                         = var.vpc_cidr_block
+  public_subnet_cidrs                    = var.public_subnet_cidrs
+  private_subnet_cidrs_eks_control_plane = var.private_subnet_cidrs_eks_control_plane
+  private_subnet_cidrs_eks_worker_nodes  = var.private_subnet_cidrs_eks_worker_nodes
+  azs_eks_control_plane                  = var.azs_eks_control_plane
+  azs_eks_worker_nodes                   = var.azs_eks_worker_nodes
+  region                                 = var.region
 }
 
 module "sage-aws-eks" {
-  source  = "spacelift.io/sagebionetworks/sage-aws-eks/aws"
-  version = "0.6.0"
+  # source  = "spacelift.io/sagebionetworks/sage-aws-eks/aws"
+  # version = "0.6.0"
+  source = "../../../modules/sage-aws-eks"
 
   cluster_name                      = var.cluster_name
-  private_vpc_subnet_ids            = module.sage-aws-vpc.private_subnet_ids
   vpc_id                            = module.sage-aws-vpc.vpc_id
   vpc_security_group_id             = module.sage-aws-vpc.vpc_security_group_id
   enable_policy_event_logs          = true
@@ -26,5 +29,10 @@ module "sage-aws-eks" {
   cloudwatch_retention              = 90
   pod_security_group_enforcing_mode = var.pod_security_group_enforcing_mode
   aws_account_id                    = var.aws_account_id
-  private_subnet_cidrs              = module.sage-aws-vpc.vpc_private_subnet_cidrs
+  private_subnet_cidrs = concat(
+    var.private_subnet_cidrs_eks_control_plane,
+    var.private_subnet_cidrs_eks_worker_nodes
+  )
+  private_subnet_ids_eks_control_plane = module.sage-aws-vpc.private_subnet_ids_eks_control_plane
+  private_subnet_ids_eks_worker_nodes  = module.sage-aws-vpc.private_subnet_ids_eks_worker_nodes
 }

--- a/deployments/stacks/dpe-k8s/outputs.tf
+++ b/deployments/stacks/dpe-k8s/outputs.tf
@@ -14,8 +14,8 @@ output "vpc_private_subnet_cidrs" {
   value = module.sage-aws-vpc.vpc_private_subnet_cidrs
 }
 
-output "private_subnet_ids" {
-  value = module.sage-aws-vpc.private_subnet_ids
+output "private_subnet_ids_eks_worker_nodes" {
+  value = module.sage-aws-vpc.private_subnet_ids_eks_worker_nodes
 }
 
 output "vpc_security_group_id" {

--- a/deployments/stacks/dpe-k8s/variables.tf
+++ b/deployments/stacks/dpe-k8s/variables.tf
@@ -35,12 +35,22 @@ variable "public_subnet_cidrs" {
   description = "Public Subnet CIDR values"
 }
 
-variable "private_subnet_cidrs" {
+variable "private_subnet_cidrs_eks_control_plane" {
   type        = list(string)
-  description = "Private Subnet CIDR values"
+  description = "Private Subnet CIDR values for the EKS control plane"
 }
 
-variable "azs" {
+variable "private_subnet_cidrs_eks_worker_nodes" {
   type        = list(string)
-  description = "Availability Zones"
+  description = "Private Subnet CIDR values for the EKS worker nodes"
+}
+
+variable "azs_eks_control_plane" {
+  type        = list(string)
+  description = "Availability Zones for the EKS control plane"
+}
+
+variable "azs_eks_worker_nodes" {
+  type        = list(string)
+  description = "Availability Zones for the EKS worker nodes"
 }

--- a/modules/sage-aws-eks/main.tf
+++ b/modules/sage-aws-eks/main.tf
@@ -104,9 +104,10 @@ module "eks" {
     }
   }
 
-  vpc_id                    = var.vpc_id
-  subnet_ids                = var.private_vpc_subnet_ids
-  control_plane_subnet_ids  = var.private_vpc_subnet_ids
+  vpc_id = var.vpc_id
+  # A list of subnet IDs where the nodes/node groups will be provisioned.
+  subnet_ids                = var.private_subnet_ids_eks_worker_nodes
+  control_plane_subnet_ids  = var.private_subnet_ids_eks_control_plane
   cluster_security_group_id = var.vpc_security_group_id
 
   iam_role_additional_policies = {

--- a/modules/sage-aws-eks/variables.tf
+++ b/modules/sage-aws-eks/variables.tf
@@ -28,9 +28,14 @@ variable "vpc_id" {
   type        = string
 }
 
-variable "private_vpc_subnet_ids" {
-  description = "List of private subnets to deploy the cluster to"
+variable "private_subnet_ids_eks_control_plane" {
   type        = list(string)
+  description = "Private Subnet ID values for the EKS control plane"
+}
+
+variable "private_subnet_ids_eks_worker_nodes" {
+  type        = list(string)
+  description = "Private Subnet ID values for the EKS worker nodes"
 }
 
 variable "private_subnet_cidrs" {

--- a/modules/sage-aws-eks/variables.tf
+++ b/modules/sage-aws-eks/variables.tf
@@ -6,7 +6,7 @@ variable "cluster_name" {
 variable "cluster_version" {
   description = "Version of K8 cluster"
   type        = string
-  default     = "1.30"
+  default     = "1.31"
 }
 
 variable "region" {

--- a/modules/sage-aws-vpc/main.tf
+++ b/modules/sage-aws-vpc/main.tf
@@ -5,8 +5,8 @@ module "vpc" {
   name = var.vpc_name
   cidr = var.vpc_cidr_block
 
-  azs             = var.azs
-  private_subnets = var.private_subnet_cidrs
+  azs             = concat(var.azs_eks_control_plane, var.azs_eks_worker_nodes)
+  private_subnets = concat(var.private_subnet_cidrs_eks_control_plane, var.private_subnet_cidrs_eks_worker_nodes)
   public_subnets  = var.public_subnet_cidrs
 
 

--- a/modules/sage-aws-vpc/ouputs.tf
+++ b/modules/sage-aws-vpc/ouputs.tf
@@ -22,6 +22,10 @@ output "vpc_public_subnet_cidrs" {
   value = var.public_subnet_cidrs
 }
 
-output "vpc_private_subnet_cidrs" {
-  value = var.private_subnet_cidrs
+output "private_subnet_ids_eks_control_plane" {
+  value = slice(module.vpc.private_subnets, 0, length(var.private_subnet_cidrs_eks_control_plane))
+}
+
+output "private_subnet_ids_eks_worker_nodes" {
+  value = slice(module.vpc.private_subnets, length(var.private_subnet_cidrs_eks_control_plane), length(var.private_subnet_cidrs_eks_worker_nodes))
 }

--- a/modules/sage-aws-vpc/ouputs.tf
+++ b/modules/sage-aws-vpc/ouputs.tf
@@ -31,5 +31,5 @@ output "private_subnet_ids_eks_control_plane" {
 }
 
 output "private_subnet_ids_eks_worker_nodes" {
-  value = slice(module.vpc.private_subnets, length(var.private_subnet_cidrs_eks_control_plane) - 1, length(var.private_subnet_cidrs_eks_worker_nodes) + 1)
+  value = slice(module.vpc.private_subnets, length(var.private_subnet_cidrs_eks_control_plane), length(module.vpc.private_subnets) + 1)
 }

--- a/modules/sage-aws-vpc/ouputs.tf
+++ b/modules/sage-aws-vpc/ouputs.tf
@@ -27,9 +27,9 @@ output "vpc_private_subnet_cidrs" {
 }
 
 output "private_subnet_ids_eks_control_plane" {
-  value = slice(module.vpc.private_subnets, 0, length(var.private_subnet_cidrs_eks_control_plane))
+  value = slice(module.vpc.private_subnets, 0, length(var.private_subnet_cidrs_eks_control_plane) + 1)
 }
 
 output "private_subnet_ids_eks_worker_nodes" {
-  value = slice(module.vpc.private_subnets, length(var.private_subnet_cidrs_eks_control_plane), length(var.private_subnet_cidrs_eks_worker_nodes))
+  value = slice(module.vpc.private_subnets, length(var.private_subnet_cidrs_eks_control_plane) - 1, length(var.private_subnet_cidrs_eks_worker_nodes) + 1)
 }

--- a/modules/sage-aws-vpc/ouputs.tf
+++ b/modules/sage-aws-vpc/ouputs.tf
@@ -27,9 +27,9 @@ output "vpc_private_subnet_cidrs" {
 }
 
 output "private_subnet_ids_eks_control_plane" {
-  value = slice(module.vpc.private_subnets, 0, length(var.private_subnet_cidrs_eks_control_plane) + 1)
+  value = slice(module.vpc.private_subnets, 0, length(var.private_subnet_cidrs_eks_control_plane))
 }
 
 output "private_subnet_ids_eks_worker_nodes" {
-  value = slice(module.vpc.private_subnets, length(var.private_subnet_cidrs_eks_control_plane), length(module.vpc.private_subnets) + 1)
+  value = slice(module.vpc.private_subnets, length(var.private_subnet_cidrs_eks_control_plane), length(module.vpc.private_subnets))
 }

--- a/modules/sage-aws-vpc/ouputs.tf
+++ b/modules/sage-aws-vpc/ouputs.tf
@@ -22,6 +22,10 @@ output "vpc_public_subnet_cidrs" {
   value = var.public_subnet_cidrs
 }
 
+output "vpc_private_subnet_cidrs" {
+  value = concat(var.private_subnet_cidrs_eks_control_plane, var.private_subnet_cidrs_eks_worker_nodes)
+}
+
 output "private_subnet_ids_eks_control_plane" {
   value = slice(module.vpc.private_subnets, 0, length(var.private_subnet_cidrs_eks_control_plane))
 }

--- a/modules/sage-aws-vpc/variables.tf
+++ b/modules/sage-aws-vpc/variables.tf
@@ -13,14 +13,24 @@ variable "public_subnet_cidrs" {
   description = "Public Subnet CIDR values"
 }
 
-variable "private_subnet_cidrs" {
+variable "private_subnet_cidrs_eks_control_plane" {
   type        = list(string)
-  description = "Private Subnet CIDR values"
+  description = "Private Subnet CIDR values for the EKS control plane"
 }
 
-variable "azs" {
+variable "private_subnet_cidrs_eks_worker_nodes" {
   type        = list(string)
-  description = "Availability Zones"
+  description = "Private Subnet CIDR values for the EKS worker nodes"
+}
+
+variable "azs_eks_control_plane" {
+  type        = list(string)
+  description = "Availability Zones for the EKS control plane"
+}
+
+variable "azs_eks_worker_nodes" {
+  type        = list(string)
+  description = "Availability Zones for the EKS worker nodes"
 }
 
 variable "region" {


### PR DESCRIPTION
Initial comment chain on issue: https://github.com/Sage-Bionetworks-Workflows/eks-stack/pull/35#discussion_r1790712362

**Problem:**

1. Khai had some recommendations on VPC sizing for the EKS cluster
2. The EKS Best Practices Guide says:

> Kubernetes worker nodes can run in the cluster subnets, but it is not recommended. During [cluster upgrades](https://aws.github.io/aws-eks-best-practices/upgrades/#verify-available-ip-addresses) Amazon EKS provisions additional ENIs in the cluster subnets. When your cluster scales out, worker nodes and pods may consume the available IPs in the cluster subnet.

**Solution:**

1. Moving VPC subnets to `/20` subnet mask which is 4094 hosts
2. Moving the EKS control plane subnets (2 AZs) to their own subnet range
3. Moving the worker subnets (3 AZs) to their own subnet range


**Deployment:**

1. Since the initial VPC ranges cannot be shrunk we must remove the VPC and set it up again
2. Since the VPC of the EKS cluster cannot be moved into another VPC we must re-create the EKS cluster.