### PR TITLE
[IBCDPE-1111] Point to updated config value

### DIFF
--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -2500,7 +2500,7 @@ config:
     # For Airflow 1.10, backward compatibility; moved to [logging] in 2.0
     colored_console_log: 'False'
     remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
-    allowed_deserialization_classes: ".*"
+    allowed_deserialization_classes_regexp: ".*"
   logging:
     remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
     colored_console_log: 'False'


### PR DESCRIPTION
**Problem:**

1. The config value to use regex was changed in 2.8.2 of airflow: https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#allowed-deserialization-classes-regexp

**Solution:**

1. Updated to the new value

**Testing:**

1. I pushed this change out and verified it was working 🤠 