### PR TITLE
[IBCDPE-1095] Use scope based authorization on telemetry upload route

### DIFF
--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -39,18 +39,22 @@ module "dpe-sandbox-spacelift-development" {
       name        = "bfauble - automation"
       description = "App for testing signoz"
       app_type    = "non_interactive"
+      scopes      = ["write:telemetry"]
     },
     {
       name        = "schematic - Github Actions"
       description = "Client for Github Actions to export telemetry data"
       app_type    = "non_interactive"
+      scopes      = ["write:telemetry"]
     },
     {
       name        = "schematic - Dev"
       description = "Client for schematic deployed to AWS DEV to export telemetry data"
       app_type    = "non_interactive"
+      scopes      = ["write:telemetry"]
     },
   ]
+  auth0_identifier = "https://dev.sagedpe.org"
 
   aws_account_id = "631692904429"
   region         = "us-east-1"

--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -104,6 +104,7 @@ module "dpe-sandbox-spacelift-production" {
   auth0_stack_project_root = "deployments/stacks/dpe-auth0"
   auth0_domain             = ""
   auth0_clients            = []
+  auth0_identifier         = ""
 
   aws_account_id = "766808016710"
   region         = "us-east-1"

--- a/deployments/spacelift/dpe-k8s/main.tf
+++ b/deployments/spacelift/dpe-k8s/main.tf
@@ -30,9 +30,10 @@ locals {
   }
 
   auth0_stack_variables = {
-    cluster_name  = var.cluster_name
-    auth0_domain  = var.auth0_domain
-    auth0_clients = var.auth0_clients
+    cluster_name     = var.cluster_name
+    auth0_domain     = var.auth0_domain
+    auth0_clients    = var.auth0_clients
+    auth0_identifier = var.auth0_identifier
   }
 
   # Variables to be passed from the k8s stack to the deployments stack

--- a/deployments/spacelift/dpe-k8s/main.tf
+++ b/deployments/spacelift/dpe-k8s/main.tf
@@ -27,6 +27,7 @@ locals {
     ssl_hostname           = var.ssl_hostname
     auth0_jwks_uri         = var.auth0_jwks_uri
     smtp_from              = var.smtp_from
+    auth0_identifier       = var.auth0_identifier
   }
 
   auth0_stack_variables = {

--- a/deployments/spacelift/dpe-k8s/variables.tf
+++ b/deployments/spacelift/dpe-k8s/variables.tf
@@ -185,7 +185,13 @@ variable "auth0_clients" {
     name        = string
     description = string
     app_type    = string
+    scopes      = list(string)
   }))
+}
+
+variable "auth0_identifier" {
+  description = "Auth0 identifier for the created API."
+  type        = string
 }
 
 variable "ses_email_identities" {

--- a/deployments/stacks/dpe-auth0/main.tf
+++ b/deployments/stacks/dpe-auth0/main.tf
@@ -53,5 +53,5 @@ resource "auth0_client_grant" "access_to_k8s_cluster" {
 
   client_id = auth0_client.oauth2_clients[each.key].id
   audience  = auth0_resource_server.k8s-cluster-api.identifier
-  scopes    = [each.value.scopes]
+  scopes    = each.value.scopes
 }

--- a/deployments/stacks/dpe-auth0/main.tf
+++ b/deployments/stacks/dpe-auth0/main.tf
@@ -1,7 +1,7 @@
 # Used to create the Auth0 resources for the DPE stack
-resource "auth0_resource_server" "k8s-cluster-telemetry" {
-  name        = "${var.cluster_name}-telemetry"
-  identifier  = "${var.cluster_name}-telemetry"
+resource "auth0_resource_server" "k8s-cluster-api" {
+  name        = "${var.cluster_name}-api"
+  identifier  = var.auth0_identifier
   signing_alg = "RS256"
 
   allow_offline_access = false
@@ -31,8 +31,8 @@ resource "auth0_client" "oauth2_clients" {
 }
 
 resource "auth0_resource_server_scopes" "k8s-cluster-scopes" {
-  resource_server_identifier = auth0_resource_server.k8s-cluster-telemetry.identifier
-  # This scope is not yet used, however, kept for future use to grant authorization based on scopes
+  resource_server_identifier = auth0_resource_server.k8s-cluster-api.identifier
+
   scopes {
     name        = "write:telemetry"
     description = "Grants write access to telemetry data"
@@ -52,6 +52,6 @@ resource "auth0_client_grant" "access_to_k8s_cluster" {
   for_each = { for client in var.auth0_clients : client.name => client }
 
   client_id = auth0_client.oauth2_clients[each.key].id
-  audience  = auth0_resource_server.k8s-cluster-telemetry.identifier
-  scopes    = []
+  audience  = auth0_resource_server.k8s-cluster-api.identifier
+  scopes    = [each.value.scopes]
 }

--- a/deployments/stacks/dpe-auth0/variables.tf
+++ b/deployments/stacks/dpe-auth0/variables.tf
@@ -24,5 +24,11 @@ variable "auth0_clients" {
     name        = string
     description = string
     app_type    = string
+    scopes      = list(string)
   }))
+}
+
+variable "auth0_identifier" {
+  description = "Auth0 identifier for the created API."
+  type        = string
 }

--- a/deployments/stacks/dpe-k8s-deployments/main.tf
+++ b/deployments/stacks/dpe-k8s-deployments/main.tf
@@ -97,7 +97,7 @@ module "signoz" {
 
 module "envoy-gateway" {
   count      = var.enable_cluster_ingress ? 1 : 0
-  depends_on = [module.argo-cd]
+  depends_on = [module.argo-cd, module.cert-manager]
   # source               = "spacelift.io/sagebionetworks/postgres-cloud-native-database/aws"
   # version              = "0.5.0"
   source               = "../../../modules/envoy-gateway"

--- a/deployments/stacks/dpe-k8s-deployments/main.tf
+++ b/deployments/stacks/dpe-k8s-deployments/main.tf
@@ -92,6 +92,7 @@ module "signoz" {
   smtp_password        = var.smtp_password
   smtp_user            = var.smtp_user
   smtp_from            = var.smtp_from
+  auth0_identifier     = var.auth0_identifier
 }
 
 module "envoy-gateway" {

--- a/deployments/stacks/dpe-k8s-deployments/variables.tf
+++ b/deployments/stacks/dpe-k8s-deployments/variables.tf
@@ -86,6 +86,11 @@ variable "auth0_jwks_uri" {
   type        = string
 }
 
+variable "auth0_identifier" {
+  description = "Auth0 identifier for the API. Used to verify the audience in the JWT."
+  type        = string
+}
+
 variable "smtp_user" {
   description = "The SMTP user. Required if smtp_user, smtp_password, and smtp_from are set"
   type        = string

--- a/modules/envoy-gateway/main.tf
+++ b/modules/envoy-gateway/main.tf
@@ -23,7 +23,7 @@ spec:
   sources:
   - repoURL: registry-1.docker.io
     chart: envoyproxy/gateway-helm
-    targetRevision: v1.1.2
+    targetRevision: v1.2.1
     helm:
       releaseName: gateway-helm
       valueFiles:

--- a/modules/envoy-gateway/templates/values.yaml
+++ b/modules/envoy-gateway/templates/values.yaml
@@ -4,7 +4,7 @@ global:
   images:
     envoyGateway:
       # This is the full image name including the hub, repo, and tag.
-      image: docker.io/envoyproxy/gateway:v1.1.2
+      image: docker.io/envoyproxy/gateway:v1.2.1
       # Specify image pull policy if default behavior isn't desired.
       # Default behavior: latest images will be Always else IfNotPresent.
       pullPolicy: IfNotPresent
@@ -12,7 +12,7 @@ global:
       pullSecrets: []
     ratelimit:
       # This is the full image name including the hub, repo, and tag.
-      image: "docker.io/envoyproxy/ratelimit:26f28d78"
+      image: "docker.io/envoyproxy/ratelimit:master"
       # Specify image pull policy if default behavior isn't desired.
       # Default behavior: latest images will be Always else IfNotPresent.
       pullPolicy: IfNotPresent
@@ -20,6 +20,8 @@ global:
       pullSecrets: []
 podDisruptionBudget:
   minAvailable: 0
+  # maxUnavailable: 1
+
 deployment:
   envoyGateway:
     image:
@@ -29,11 +31,21 @@ deployment:
     imagePullSecrets: []
     resources:
       limits:
-        cpu: 500m
         memory: 1024Mi
       requests:
         cpu: 100m
         memory: 256Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      runAsNonRoot: true
+      runAsGroup: 65532
+      runAsUser: 65532
+      seccompProfile:
+        type: RuntimeDefault
   ports:
     - name: grpc
       port: 18000
@@ -47,6 +59,7 @@ deployment:
     - name: metrics
       port: 19001
       targetPort: 19001
+  priorityClassName: null
   replicas: 1
   pod:
     affinity: {}
@@ -56,6 +69,10 @@ deployment:
     labels: {}
     topologySpreadConstraints: []
     tolerations: []
+    nodeSelector: {}
+
+service:
+  annotations: {}
 
 config:
   envoyGateway:
@@ -76,7 +93,22 @@ certgen:
   job:
     annotations: {}
     resources: {}
+    affinity: {}
+    tolerations: []
+    nodeSelector: {}
     ttlSecondsAfterFinished: 30
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsGroup: 65534
+      runAsUser: 65534
+      seccompProfile:
+        type: RuntimeDefault
   rbac:
     annotations: {}
     labels: {}

--- a/modules/signoz/main.tf
+++ b/modules/signoz/main.tf
@@ -86,7 +86,7 @@ spec:
                 remoteJWKS:
                   uri: ${var.auth0_jwks_uri}
                 audiences:
-                  - ${var.cluster_name}-telemetry
+                  - ${var.auth0_identifier}
           - op: replace
             path: /spec/authorization
             value:

--- a/modules/signoz/main.tf
+++ b/modules/signoz/main.tf
@@ -87,6 +87,18 @@ spec:
                   uri: ${var.auth0_jwks_uri}
                 audiences:
                   - ${var.cluster_name}-telemetry
+          - op: replace
+            path: /spec/authorization
+            value:
+              defaultAction: Deny
+              rules:
+              - name: allow
+                action: Allow
+                principal:
+                  jwt:
+                    provider: auth0
+                    scopes:
+                      - write:telemetry
   %{endif}
   destination:
     server: 'https://kubernetes.default.svc'

--- a/modules/signoz/resources-otel-ingress/security-policy.yaml
+++ b/modules/signoz/resources-otel-ingress/security-policy.yaml
@@ -9,5 +9,5 @@ spec:
     kind: HTTPRoute
     name: signoz-otel-collector-route
   jwt:
-    providers: <replaced-by-kustomize>
     authorization: <replaced-by-kustomize>
+  providers: <replaced-by-kustomize>

--- a/modules/signoz/resources-otel-ingress/security-policy.yaml
+++ b/modules/signoz/resources-otel-ingress/security-policy.yaml
@@ -9,5 +9,5 @@ spec:
     kind: HTTPRoute
     name: signoz-otel-collector-route
   jwt:
-    authorization: <replaced-by-kustomize>
-  providers: <replaced-by-kustomize>
+    providers: <replaced-by-kustomize>
+  authorization: <replaced-by-kustomize>

--- a/modules/signoz/resources-otel-ingress/security-policy.yaml
+++ b/modules/signoz/resources-otel-ingress/security-policy.yaml
@@ -10,3 +10,4 @@ spec:
     name: signoz-otel-collector-route
   jwt:
     providers: <replaced-by-kustomize>
+    authorization: <replaced-by-kustomize>

--- a/modules/signoz/variables.tf
+++ b/modules/signoz/variables.tf
@@ -48,6 +48,11 @@ variable "auth0_jwks_uri" {
   type        = string
 }
 
+variable "auth0_identifier" {
+  description = "Auth0 identifier for the API. Used to verify the audience in the JWT."
+  type        = string
+}
+
 variable "smtp_user" {
   description = "The SMTP user. Required if smtp_user, smtp_password, and smtp_from are set"
   type        = string


### PR DESCRIPTION
**Problem:**

1. Prior to envoy gateway 1.2.x the only way to perform any sort of claim/scope based authorization was to deploy out a opa/rego server (Or other mechanism) and perform that authorization externally. They introduced (last week) the ability to defined authorization checks in the SecurityPolicy objects.

**Solution:**

1. Using a `write:telemetry` scope on the JWT claim to add an extra level of authorization checks.
2. Set the audience back to a more generic level of the entire cluster, instead of specific to telemetry.


**Testing:**

1. I tested this on our sandbox k8s cluster. I verified that without the required scopes you get an error, and with the scopes the request is accepted as expected.

When you get an error it gets rejected with an HTTP 403:
`ERROR:opentelemetry.exporter.otlp.proto.http._log_exporter:Failed to export logs batch code: 403, reason: RBAC: access denied`


An example JWT claims look like:
```
{
  "iss": "https://dev-sage-dpe.us.auth0.com/",
  "sub": "aT3uJr1erUmJ9CWnX4CyMXHROX2OAvCA@clients",
  "aud": "https://dev.sagedpe.org",
  "iat": 1731543026,
  "exp": 1731651026,
  "scope": "write:telemetry",
  "gty": "client-credentials",
  "azp": "aT3uJr1erUmJ9CWnX4CyMXHROX2OAvCA"
}
```


Further reading:
https://gateway.envoyproxy.io/docs/tasks/security/jwt-claim-authorization/