### PR TITLE
[SCHEMATIC-215] Enable ingress for SigNoz UI

### DIFF
--- a/modules/envoy-gateway/resources/envoy-proxy.yaml
+++ b/modules/envoy-gateway/resources/envoy-proxy.yaml
@@ -4,3 +4,9 @@ metadata:
   name: custom-proxy-config
 spec:
   mergeGateways: false
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyService:
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"

--- a/modules/envoy-gateway/resources/traffic-policy.yaml
+++ b/modules/envoy-gateway/resources/traffic-policy.yaml
@@ -9,3 +9,4 @@ spec:
       name: eg
   tls:
     minVersion: "1.3"
+  enableProxyProtocol: true

--- a/modules/signoz/main.tf
+++ b/modules/signoz/main.tf
@@ -251,6 +251,7 @@ spec:
           value: ${var.namespace}
     - target:
         kind: SecurityPolicy
+        name: require-jwt-for-collector
       patch: |-
         - op: replace
           path: /metadata/namespace

--- a/modules/signoz/resources-otel-ingress/http-route.yaml
+++ b/modules/signoz/resources-otel-ingress/http-route.yaml
@@ -60,7 +60,7 @@ spec:
           weight: 1
       matches:
         - path:
-            type: PathPrefix
+            type: Exact
             value: /
         - headers:
             - name: Referer

--- a/modules/signoz/resources-otel-ingress/http-route.yaml
+++ b/modules/signoz/resources-otel-ingress/http-route.yaml
@@ -51,3 +51,17 @@ spec:
         - path:
             type: PathPrefix
             value: /telemetry/ui
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: signoz-frontend
+          namespace: signoz
+          port: 3301
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+        - headers:
+            - name: Referer
+              value: https://dev.sagedpe.org/telemetry/ui

--- a/modules/signoz/resources-otel-ingress/http-route.yaml
+++ b/modules/signoz/resources-otel-ingress/http-route.yaml
@@ -41,27 +41,7 @@ spec:
           namespace: signoz
           port: 3301
           weight: 1
-      filters:
-      - type: URLRewrite
-        urlRewrite:
-          path:
-            type: ReplacePrefixMatch
-            replacePrefixMatch: /
       matches:
         - path:
             type: PathPrefix
-            value: /telemetry/ui
-    - backendRefs:
-        - group: ""
-          kind: Service
-          name: signoz-frontend
-          namespace: signoz
-          port: 3301
-          weight: 1
-      matches:
-        - path:
-            type: Exact
             value: /
-        - headers:
-            - name: Referer
-              value: https://dev.sagedpe.org/telemetry/ui

--- a/modules/signoz/resources-otel-ingress/http-route.yaml
+++ b/modules/signoz/resources-otel-ingress/http-route.yaml
@@ -24,3 +24,30 @@ spec:
         - path:
             type: PathPrefix
             value: /telemetry/v1
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: signoz-ui-route
+  namespace: envoy-gateway
+spec:
+  parentRefs:
+    - name: eg
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: signoz-frontend
+          namespace: signoz
+          port: 3301
+          weight: 1
+      filters:
+      - type: URLRewrite
+        urlRewrite:
+          path:
+            type: ReplacePrefixMatch
+            replacePrefixMatch: /
+      matches:
+        - path:
+            type: PathPrefix
+            value: /telemetry/ui

--- a/modules/signoz/resources-otel-ingress/reference-grant-signoz.yaml
+++ b/modules/signoz/resources-otel-ingress/reference-grant-signoz.yaml
@@ -12,3 +12,7 @@ spec:
   - group: ""
     kind: Service
     name: signoz-otel-collector
+  - group: ""
+    kind: Service
+    name: signoz-frontend
+

--- a/modules/signoz/resources-otel-ingress/security-policy.yaml
+++ b/modules/signoz/resources-otel-ingress/security-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:
-  name: require-audience-for-authorization
+  name: require-jwt-for-collector
   namespace: envoy-gateway
 spec:
   targetRef:
@@ -11,3 +11,22 @@ spec:
   jwt:
     providers: <replaced-by-kustomize>
   authorization: <replaced-by-kustomize>
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: restrict-ui-to-sage-vpn
+  namespace: envoy-gateway
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: signoz-ui-route
+  authorization:
+    defaultAction: Deny
+    rules:
+    - action: Allow
+      principal:
+        clientCIDRs:
+        # Public IP address for the Sage VPN. `/32` CIDR mask means a single IP address.
+        - 52.44.61.21/32


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/SCHEMATIC-215

**Problem:**

1. SigNoz (Non-Enterprise) uses their own login mechanism that doesn't support SSO/SAML; We are reluctant to add JumpCloud SSO in-front of SigNoz as it will then require a 2-step login.
2. The Sage VPN is a viable option that requires users to be on the Sage VPN. As such we need to create a route to access the UI and restrict it to the public IP address.

**Solution:**

1. Creating a route in the Envoy Gateway to access the SigNoz UI.
2. Enable proxy protocol on the AWS load balancer to support forwarding the real client IP address via the `X-Forwarded-For` header.
3. Use an `authorization` SecurityPolicy to restrict access to the SigNoz HTTP route

**Testing:**

- [x] To deploy and test on k8s sandbox cluster
- I verified that the URL is accessible via the `dev` url:

![image](https://github.com/user-attachments/assets/c93d68e8-a5bb-47ad-8453-fe4454fe717b)
