### PR TITLE
[DPE-1248] Upgrade trivy operator for AWS EKS 1.31 upgrade

### DIFF
--- a/deployments/stacks/dpe-k8s-deployments/main.tf
+++ b/deployments/stacks/dpe-k8s-deployments/main.tf
@@ -51,7 +51,7 @@ module "trivy-operator" {
   source       = "../../../modules/trivy-operator"
   auto_deploy  = var.auto_deploy
   auto_prune   = var.auto_prune
-  git_revision = "dpe-1248-upgrade-trivy-operator"
+  git_revision = local.git_revision
 }
 
 module "airflow" {

--- a/deployments/stacks/dpe-k8s-deployments/main.tf
+++ b/deployments/stacks/dpe-k8s-deployments/main.tf
@@ -51,7 +51,7 @@ module "trivy-operator" {
   source       = "../../../modules/trivy-operator"
   auto_deploy  = var.auto_deploy
   auto_prune   = var.auto_prune
-  git_revision = local.git_revision
+  git_revision = "dpe-1248-upgrade-trivy-operator"
 }
 
 module "airflow" {

--- a/modules/trivy-operator/main.tf
+++ b/modules/trivy-operator/main.tf
@@ -23,7 +23,7 @@ spec:
   sources:
   - repoURL: 'https://aquasecurity.github.io/helm-charts/'
     chart: trivy-operator
-    targetRevision: 0.24.1
+    targetRevision: 0.26.1
     helm:
       releaseName: trivy-operator
       valueFiles:

--- a/modules/trivy-operator/templates/values-trivy-operator.yaml
+++ b/modules/trivy-operator/templates/values-trivy-operator.yaml
@@ -20,6 +20,21 @@ targetNamespaces: ""
 # mode, i.e. when the targetNamespaces values is a blank string.
 excludeNamespaces: ""
 
+# -- extraEnv is a list of extra environment variables for the trivy-operator.
+extraEnv: []
+
+# -- hostAliases for `deployment` (TrivyOperator) and `statefulset` (TrivyServer)
+
+hostAliases: []
+# - ip: "127.0.0.1"
+#   hostnames:
+#   - "foo.local"
+#   - "bar.local"
+# - ip: "10.1.2.3"
+#   hostnames:
+#   - "foo.remote"
+#   - "bar.remote"
+
 # -- targetWorkloads is a comma seperated list of Kubernetes workload resources
 # to be included in the vulnerability and config-audit scans
 # if left blank, all workload resources will be scanned
@@ -185,8 +200,8 @@ operator:
   valuesFromSecret: ""
 
 image:
-  registry: "ghcr.io"
-  repository: "aquasecurity/trivy-operator"
+  registry: "mirror.gcr.io"
+  repository: "aquasec/trivy-operator"
   # -- tag is an override of the image tag, which is by default set by the
   # appVersion field in Chart.yaml.
   tag: ""
@@ -336,11 +351,11 @@ trivy:
   createConfig: true
   image:
     # -- registry of the Trivy image
-    registry: ghcr.io
+    registry: mirror.gcr.io
     # -- repository of the Trivy image
-    repository: aquasecurity/trivy
+    repository: aquasec/trivy
     # -- tag version of the Trivy image
-    tag: 0.53.0
+    tag: 0.59.1
     # -- imagePullSecret is the secret name to be used when pulling trivy image from private registries example : reg-secret
     # It is the user responsibility to create the secret for the private registry in `trivy-operator` namespace
     imagePullSecret: ~
@@ -517,8 +532,8 @@ trivy:
   serverCustomHeaders: ~
   # serverCustomHeaders: "foo=bar"
 
-  dbRegistry: "ghcr.io"
-  dbRepository: "aquasecurity/trivy-db"
+  dbRegistry: "mirror.gcr.io"
+  dbRepository: "aquasec/trivy-db"
 
   # -- The username for dbRepository authentication
   #
@@ -529,14 +544,14 @@ trivy:
   dbRepositoryPassword: ~
 
   # -- javaDbRegistry is the registry for the Java vulnerability database.
-  javaDbRegistry: "ghcr.io"
-  javaDbRepository: "aquasecurity/trivy-java-db"
+  javaDbRegistry: "mirror.gcr.io"
+  javaDbRepository: "aquasec/trivy-java-db"
 
   # -- The Flag to enable insecure connection for downloading trivy-db via proxy (air-gaped env)
   #
   dbRepositoryInsecure: "false"
 
-  # -- The Flag to enable the usage of builtin rego policies by default, these policies are downloaded by default from ghcr.io/aquasecurity/trivy-checks
+  # -- The Flag to enable the usage of builtin rego policies by default, these policies are downloaded by default from mirror.gcr.io/aquasec/trivy-checks
   #
   useBuiltinRegoPolicies: "true"
   # -- The Flag to enable the usage of external rego policies config-map, this should be used when the user wants to use their own rego policies
@@ -544,7 +559,7 @@ trivy:
   externalRegoPoliciesEnabled: false
   # -- To enable the usage of embedded rego policies, set the flag useEmbeddedRegoPolicies. This should serve as a fallback for air-gapped environments.
   # When useEmbeddedRegoPolicies is set to true, useBuiltinRegoPolicies should be set to false.
-  useEmbeddedRegoPolicies: "false"
+  useEmbeddedRegoPolicies: "true"
 
   # -- The Flag is the list of supported kinds separated by comma delimiter to be scanned by the config audit scanner
   #
@@ -608,7 +623,6 @@ compliance:
   # -- reportType this flag control the type of report generated (summary or all)
   reportType: summary
   # -- cron this flag control the cron interval for compliance report generation
-  # At minute 0 past every 6th hour.
   cron: 0 */6 * * *
   # -- specs is a list of compliance specs to be used by the cluster compliance scanner
   #  - k8s-cis-1.23
@@ -637,7 +651,7 @@ serviceAccount:
 podAnnotations: {}
 
 podSecurityContext: {}
-  # fsGroup: 2000
+# fsGroup: 2000
 
 # -- securityContext security context
 securityContext:
@@ -659,13 +673,18 @@ volumes:
   - name: cache-policies
     emptyDir: {}
 
-resources:
-  limits:
-    cpu: 1
-    memory: 1Gi
-  requests:
-    cpu: 100m
-    memory: 128Mi
+resources: {}
+# -- We usually recommend not to specify default resources and to leave this as a conscious
+# choice for the user. This also increases chances charts run on environments with little
+# resources, such as Minikube. If you do want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+# limits:
+#   cpu: 100m
+#   memory: 128Mi
+# requests:
+#   cpu: 100m
+#   memory: 128Mi
+
 # -- nodeSelector set the operator nodeSelector
 nodeSelector: {}
 
@@ -678,17 +697,17 @@ affinity: {}
 # -- priorityClassName set the operator priorityClassName
 priorityClassName: ""
 
-  # -- automountServiceAccountToken the flag to enable automount for service account token
+# -- automountServiceAccountToken the flag to enable automount for service account token
 automountServiceAccountToken: true
 
 policiesBundle:
   # -- registry of the policies bundle
-  registry: ghcr.io
+  registry: mirror.gcr.io
   # -- repository of the policies bundle
-  repository: aquasecurity/trivy-checks
+  repository: aquasec/trivy-checks
   # -- tag version of the policies bundle
-  tag: 0
-   # -- registryUser is the user for the registry
+  tag: 1
+  # -- registryUser is the user for the registry
   registryUser: ~
   # -- registryPassword is the password for the registry
   registryPassword: ~
@@ -699,7 +718,6 @@ policiesBundle:
   existingSecret: false
   # -- insecure is the flag to enable insecure connection to the policy bundle registry
   insecure: false
-
 
 nodeCollector:
   # -- useNodeSelector determine if to use nodeSelector (by auto detecting node name) with node-collector scan job


### PR DESCRIPTION
Problem:

1. https://github.com/aquasecurity/trivy-operator/issues/2251 describes the given issue for the current version of the trivy operator. It is not fully-compatible with the 1.31 upgrade of AWS EKS.

Solution:

1. Upgrade to the latest trivy operator helm chart of 0.26.1

Testing:

- [x] Will be testing in the sandbox EKS cluster

I verified that resources that were not showing before (Software bill of materials, and vulnerability reports) are correctly generating:
![image](https://github.com/user-attachments/assets/631dbd8c-7247-4df3-829c-b347ee69cc0c)
![image](https://github.com/user-attachments/assets/b7f56a82-c9fe-49bb-9398-5d4bfacc5eb3)
