### PR TITLE
[DPE-1234] Create S3 croissant bucket in DPE aws account

### DIFF
--- a/deployments/stacks/dpe-k8s/main.tf
+++ b/deployments/stacks/dpe-k8s/main.tf
@@ -52,4 +52,5 @@ module "synapse_dataset_to_crossiant_metadata" {
   aws_account_id = var.aws_account_id
   cluster_name = var.cluster_name
   cluster_oidc_provider_arn = module.sage-aws-eks.cluster_oidc_provider_arn
+  public_access = true
 }

--- a/deployments/stacks/dpe-k8s/main.tf
+++ b/deployments/stacks/dpe-k8s/main.tf
@@ -47,7 +47,7 @@ module "sage-aws-ses" {
 module "synapse_dataset_to_crossiant_metadata" {
   count  = var.cluster_name == "dpe-k8" ? 1 : 0
   source      = "../../../modules/s3-bucket"
-  bucket_name = "synapse-croissant-metadata"
+  bucket_name = "synapse-croissant-metadata-2"
   enable_versioning = true
   aws_account_id = var.aws_account_id
   cluster_name = var.cluster_name

--- a/deployments/stacks/dpe-k8s/main.tf
+++ b/deployments/stacks/dpe-k8s/main.tf
@@ -43,3 +43,13 @@ module "sage-aws-ses" {
 
   email_identities = var.ses_email_identities
 }
+
+module "synapse_dataset_to_crossiant_metadata" {
+  count  = var.cluster_name == "dpe-k8-sandbox" ? 1 : 0
+  source      = "../../../modules/s3-bucket"
+  bucket_name = "synapse-croissant-metadata"
+  enable_versioning = true
+  aws_account_id = var.aws_account_id
+  cluster_name = var.cluster_name
+  cluster_oidc_provider_arn = module.sage-aws-eks.cluster_oidc_provider_arn
+}

--- a/deployments/stacks/dpe-k8s/main.tf
+++ b/deployments/stacks/dpe-k8s/main.tf
@@ -45,7 +45,7 @@ module "sage-aws-ses" {
 }
 
 module "synapse_dataset_to_crossiant_metadata" {
-  count  = var.cluster_name == "dpe-k8-sandbox" ? 1 : 0
+  count  = var.cluster_name == "----------dpe-k8-sandbox" ? 1 : 0
   source      = "../../../modules/s3-bucket"
   bucket_name = "synapse-croissant-metadata"
   enable_versioning = true

--- a/deployments/stacks/dpe-k8s/main.tf
+++ b/deployments/stacks/dpe-k8s/main.tf
@@ -44,13 +44,13 @@ module "sage-aws-ses" {
   email_identities = var.ses_email_identities
 }
 
-# module "synapse_dataset_to_crossiant_metadata" {
-#   count  = var.cluster_name == "dpe-k8-sandbox" ? 1 : 0
-#   source      = "../../../modules/s3-bucket"
-#   bucket_name = "synapse-croissant-metadata"
-#   enable_versioning = true
-#   aws_account_id = var.aws_account_id
-#   cluster_name = var.cluster_name
-#   cluster_oidc_provider_arn = module.sage-aws-eks.cluster_oidc_provider_arn
-#   public_access = true
-# }
+module "synapse_dataset_to_crossiant_metadata" {
+  count  = var.cluster_name == "dpe-k8-sandbox" ? 1 : 0
+  source      = "../../../modules/s3-bucket"
+  bucket_name = "synapse-croissant-metadata"
+  enable_versioning = true
+  aws_account_id = var.aws_account_id
+  cluster_name = var.cluster_name
+  cluster_oidc_provider_arn = module.sage-aws-eks.cluster_oidc_provider_arn
+  public_access = true
+}

--- a/deployments/stacks/dpe-k8s/main.tf
+++ b/deployments/stacks/dpe-k8s/main.tf
@@ -45,9 +45,10 @@ module "sage-aws-ses" {
 }
 
 module "synapse_dataset_to_crossiant_metadata" {
+  # This points to the prod cluster - The only location where we want to create the bucket
   count  = var.cluster_name == "dpe-k8" ? 1 : 0
   source      = "../../../modules/s3-bucket"
-  bucket_name = "synapse-croissant-metadata-2"
+  bucket_name = "synapse-croissant-metadata"
   enable_versioning = true
   aws_account_id = var.aws_account_id
   cluster_name = var.cluster_name

--- a/deployments/stacks/dpe-k8s/main.tf
+++ b/deployments/stacks/dpe-k8s/main.tf
@@ -45,12 +45,12 @@ module "sage-aws-ses" {
 }
 
 module "synapse_dataset_to_crossiant_metadata" {
-  count  = var.cluster_name == "dpe-k8-sandbox" ? 1 : 0
+  count  = var.cluster_name == "dpe-k8" ? 1 : 0
   source      = "../../../modules/s3-bucket"
   bucket_name = "synapse-croissant-metadata"
   enable_versioning = true
   aws_account_id = var.aws_account_id
   cluster_name = var.cluster_name
   cluster_oidc_provider_arn = module.sage-aws-eks.cluster_oidc_provider_arn
-  public_access = true
+  public_access = false
 }

--- a/deployments/stacks/dpe-k8s/main.tf
+++ b/deployments/stacks/dpe-k8s/main.tf
@@ -44,13 +44,13 @@ module "sage-aws-ses" {
   email_identities = var.ses_email_identities
 }
 
-module "synapse_dataset_to_crossiant_metadata" {
-  count  = var.cluster_name == "----------dpe-k8-sandbox" ? 1 : 0
-  source      = "../../../modules/s3-bucket"
-  bucket_name = "synapse-croissant-metadata"
-  enable_versioning = true
-  aws_account_id = var.aws_account_id
-  cluster_name = var.cluster_name
-  cluster_oidc_provider_arn = module.sage-aws-eks.cluster_oidc_provider_arn
-  public_access = true
-}
+# module "synapse_dataset_to_crossiant_metadata" {
+#   count  = var.cluster_name == "dpe-k8-sandbox" ? 1 : 0
+#   source      = "../../../modules/s3-bucket"
+#   bucket_name = "synapse-croissant-metadata"
+#   enable_versioning = true
+#   aws_account_id = var.aws_account_id
+#   cluster_name = var.cluster_name
+#   cluster_oidc_provider_arn = module.sage-aws-eks.cluster_oidc_provider_arn
+#   public_access = true
+# }

--- a/modules/s3-bucket/main.tf
+++ b/modules/s3-bucket/main.tf
@@ -39,7 +39,7 @@ resource "aws_s3_bucket_acl" "bucket_acl" {
 
 resource "aws_s3_bucket_policy" "my_bucket_policy" {
   count = var.public_access ? 1 : 0
-  bucket = aws_s3_bucket.my_bucket.bucket
+  bucket = aws_s3_bucket.bucket.bucket
 
   policy = jsonencode({
     Version = "2012-10-17",

--- a/modules/s3-bucket/main.tf
+++ b/modules/s3-bucket/main.tf
@@ -12,7 +12,7 @@ resource "aws_s3_bucket_ownership_controls" "ownership" {
   count = var.public_access ? 1 : 0
   bucket = aws_s3_bucket.bucket.id
   rule {
-    object_ownership = "BucketOwnerEnforced"
+    object_ownership = "BucketOwnerPreferred"
   }
 }
 

--- a/modules/s3-bucket/main.tf
+++ b/modules/s3-bucket/main.tf
@@ -37,6 +37,23 @@ resource "aws_s3_bucket_acl" "bucket_acl" {
   acl    = "public-read"
 }
 
+resource "aws_s3_bucket_policy" "my_bucket_policy" {
+  count = var.public_access ? 1 : 0
+  bucket = aws_s3_bucket.my_bucket.bucket
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = "*",
+        Action = "s3:GetObject",
+        Resource = "${aws_s3_bucket.bucket.arn}/*",  # Allow access to all objects within the bucket
+      },
+    ],
+  })
+}
+
 resource "aws_s3_bucket_versioning" "versioning" {
   bucket = aws_s3_bucket.bucket.id
   versioning_configuration {

--- a/modules/s3-bucket/main.tf
+++ b/modules/s3-bucket/main.tf
@@ -8,6 +8,35 @@ resource "aws_s3_bucket" "bucket" {
   )
 }
 
+resource "aws_s3_bucket_ownership_controls" "ownership" {
+  count = var.public_access ? 1 : 0
+  bucket = aws_s3_bucket.bucket.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "access_block" {
+  count = var.public_access ? 1 : 0
+  bucket = aws_s3_bucket.bucket.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_acl" "bucket_acl" {
+  count = var.public_access ? 1 : 0
+  depends_on = [
+    aws_s3_bucket_ownership_controls.ownership,
+    aws_s3_bucket_public_access_block.access_block,
+  ]
+
+  bucket = aws_s3_bucket.bucket.id
+  acl    = "public-read"
+}
+
 resource "aws_s3_bucket_versioning" "versioning" {
   bucket = aws_s3_bucket.bucket.id
   versioning_configuration {

--- a/modules/s3-bucket/variables.tf
+++ b/modules/s3-bucket/variables.tf
@@ -31,3 +31,9 @@ variable "cluster_oidc_provider_arn" {
   description = "EKS cluster ARN for the oidc provider"
   type        = string
 }
+
+variable "public_access" {
+  description = "Enable/block public access to the bucket"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
# **Problem:**

- A public S3 bucket is needed in the DPE account in order to handle the creation and access of croissant files created from Synapse Datasets. This [design doc describes](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/4006379521/DPE-1234+Automate+Synapse+Dataset+to+Croissant+JSON-LD+Files) the overall process for getting this data out of Snowflake and into these croissant files.

# **Solution:**

- Updating the s3 bucket module to support creating the bucket with public availability
- Add the creation of an S3 bucket to the DPE Prod stack so it will be created in the `org-sagebase-dpe-prod` AWS account

# **Testing:**

- I was able to verify in the DPE test AWS account that I could create an S3 bucket without public access, then after flipping the boolean, observe that the bucket could be listed by the public, and files could be read by the public.
