### PR TITLE
[DPE-1276] Update airflow values.yaml to use a new airflow version

### DIFF
--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -1903,8 +1903,6 @@ dagProcessor:
     securityContexts:
       container: {}
 
-    env: []
-
   waitForMigrations:
     # Whether to create init container to wait for db migrations
     enabled: true

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -68,13 +68,13 @@ airflowHome: /opt/airflow
 defaultAirflowRepository: ghcr.io/sage-bionetworks-workflows/orca-recipes
 
 # Default airflow tag to deploy
-defaultAirflowTag: "0.1.0"
+defaultAirflowTag: "0.2.0"
 
 # Default airflow digest. If specified, it takes precedence over tag
 defaultAirflowDigest: ~
 
 # Airflow version (Used to make some decisions based on Airflow Version being deployed)
-airflowVersion: "2.9.3"
+airflowVersion: "2.10.5"
 
 # Images
 images:
@@ -105,7 +105,7 @@ images:
     pullPolicy: IfNotPresent
   statsd:
     repository: quay.io/prometheus/statsd-exporter
-    tag: v0.26.1
+    tag: v0.28.0
     pullPolicy: IfNotPresent
   redis:
     repository: redis
@@ -115,7 +115,7 @@ images:
     pullPolicy: IfNotPresent
   pgbouncer:
     repository: apache/airflow
-    tag: airflow-pgbouncer-2024.01.19-1.21.0
+    tag: airflow-pgbouncer-2025.01.10-1.24.0
     pullPolicy: IfNotPresent
   pgbouncerExporter:
     repository: apache/airflow
@@ -123,7 +123,7 @@ images:
     pullPolicy: IfNotPresent
   gitSync:
     repository: registry.k8s.io/git-sync/git-sync
-    tag: v4.1.0
+    tag: v4.3.0
     pullPolicy: IfNotPresent
 
 # Select certain nodes for airflow pods.
@@ -162,7 +162,7 @@ ingress:
 
     # The hostnames or hosts configuration for the web Ingress
     hosts: []
-    #   # The hostname for the web Ingress (can be templated)
+    #   # The hostname for the web Ingress (templated)
     # - name: ""
     #   # configs for web Ingress TLS
     #   tls:
@@ -206,7 +206,7 @@ ingress:
 
     # The hostnames or hosts configuration for the flower Ingress
     hosts: []
-    #   # The hostname for the flower Ingress (can be templated)
+    #   # The hostname for the flower Ingress (templated)
     # - name: ""
     #   tls:
     #     # Enable TLS termination for the flower Ingress
@@ -224,6 +224,66 @@ ingress:
       # the name of a pre-created Secret containing a TLS private key and certificate
       secretName: ""
 
+  # Configs for the Ingress of the statsd Service
+  statsd:
+    # Enable web ingress resource
+    enabled: false
+
+    # Annotations for the statsd Ingress
+    annotations: {}
+
+    # The path for the statsd Ingress
+    path: "/metrics"
+
+    # The pathType for the above path (used only with Kubernetes v1.19 and above)
+    pathType: "ImplementationSpecific"
+
+    # The hostname for the statsd Ingress (Deprecated - renamed to `ingress.statsd.hosts`)
+    host: ""
+
+    # The hostnames or hosts configuration for the statsd Ingress
+    hosts: []
+    #   # The hostname for the statsd Ingress (templated)
+    # - name: ""
+    #   tls:
+    #     # Enable TLS termination for the statsd Ingress
+    #     enabled: false
+    #     # the name of a pre-created Secret containing a TLS private key and certificate
+    #     secretName: ""
+
+    # The Ingress Class for the statsd Ingress (used only with Kubernetes v1.19 and above)
+    ingressClassName: ""
+
+  # Configs for the Ingress of the pgbouncer Service
+  pgbouncer:
+    # Enable web ingress resource
+    enabled: false
+
+    # Annotations for the pgbouncer Ingress
+    annotations: {}
+
+    # The path for the pgbouncer Ingress
+    path: "/metrics"
+
+    # The pathType for the above path (used only with Kubernetes v1.19 and above)
+    pathType: "ImplementationSpecific"
+
+    # The hostname for the pgbouncer Ingress (Deprecated - renamed to `ingress.pgbouncer.hosts`)
+    host: ""
+
+    # The hostnames or hosts configuration for the pgbouncer Ingress
+    hosts: []
+    #   # The hostname for the statsd Ingress (templated)
+    # - name: ""
+    #   tls:
+    #     # Enable TLS termination for the pgbouncer Ingress
+    #     enabled: false
+    #     # the name of a pre-created Secret containing a TLS private key and certificate
+    #     secretName: ""
+
+    # The Ingress Class for the pgbouncer Ingress (used only with Kubernetes v1.19 and above)
+    ingressClassName: ""
+
 # Network policy configuration
 networkPolicies:
   # Enabled network policies
@@ -237,7 +297,7 @@ airflowPodAnnotations: {}
 # main Airflow configmap
 airflowConfigAnnotations: {}
 
-# `airflow_local_settings` file as a string (can be templated).
+# `airflow_local_settings` file as a string (templated).
 airflowLocalSettings: |-
   {{- if semverCompare ">=2.2.0" .Values.airflowVersion }}
   {{- if not (or .Values.webserverSecretKey .Values.webserverSecretKeySecretName) }}
@@ -266,6 +326,7 @@ rbac:
 
 # Airflow executor
 # One of: LocalExecutor, LocalKubernetesExecutor, CeleryExecutor, KubernetesExecutor, CeleryKubernetesExecutor
+# Specify executors in a prioritized list to leverage multiple execution environments as needed.
 executor: "CeleryExecutor"
 
 # If this is true and using LocalExecutor/KubernetesExecutor/CeleryKubernetesExecutor, the scheduler's
@@ -307,6 +368,7 @@ enableBuiltInSecretEnvVars:
   AIRFLOW__CELERY__BROKER_URL: true
   AIRFLOW__ELASTICSEARCH__HOST: true
   AIRFLOW__ELASTICSEARCH__ELASTICSEARCH_HOST: true
+  AIRFLOW__OPENSEARCH__HOST: true
 
 # Priority Classes that will be installed by charts.
 # Ideally, there should be an entry for dagProcessor, flower,
@@ -326,9 +388,9 @@ priorityClasses: []
 # Extra secrets that will be managed by the chart
 # (You can use them with extraEnv or extraEnvFrom or some of the extraVolumes values).
 # The format for secret data is "key/value" where
-#    * key (can be templated) is the name of the secret that will be created
+#    * key (templated) is the name of the secret that will be created
 #    * value: an object with the standard 'data' or 'stringData' key (or both).
-#          The value associated with those keys must be a string (can be templated)
+#          The value associated with those keys must be a string (templated)
 extraSecrets: {}
 # eg:
 # extraSecrets:
@@ -353,9 +415,9 @@ extraSecrets: {}
 # Extra ConfigMaps that will be managed by the chart
 # (You can use them with extraEnv or extraEnvFrom or some of the extraVolumes values).
 # The format for configmap data is "key/value" where
-#    * key (can be templated) is the name of the configmap that will be created
+#    * key (templated) is the name of the configmap that will be created
 #    * value: an object with the standard 'data' key.
-#          The value associated with this keys must be a string (can be templated)
+#          The value associated with this keys must be a string (templated)
 extraConfigMaps: {}
 # eg:
 # extraConfigMaps:
@@ -367,7 +429,7 @@ extraConfigMaps: {}
 #       AIRFLOW_VAR_KUBERNETES_NAMESPACE: "{{ .Release.Namespace }}"
 
 # Extra env 'items' that will be added to the definition of airflow containers
-# a string is expected (can be templated).
+# a string is expected (templated).
 # TODO: difference from `env`? This is a templated string. Probably should template `env` and remove this.
 extraEnv: ~
 # eg:
@@ -532,6 +594,9 @@ workers:
       maxSurge: "100%"
       maxUnavailable: "50%"
 
+  # Allow relaxing ordering guarantees while preserving its uniqueness and identity
+  # podManagementPolicy: Parallel
+
   # When not set, the values defined in the global securityContext will be used
   securityContext: {}
   #  runAsUser: 50000
@@ -594,7 +659,8 @@ workers:
       SELECT ceil(COUNT(*)::decimal / {{ .Values.config.celery.worker_concurrency }})
       FROM task_instance
       WHERE (state='running' OR state='queued')
-      {{- if eq .Values.executor "CeleryKubernetesExecutor" }}
+      {{- if or (contains "CeleryKubernetesExecutor" .Values.executor)
+      (contains "KubernetesExecutor" .Values.executor) }}
       AND queue != '{{ .Values.config.celery_kubernetes_executor.kubernetes_queue }}'
       {{- end }}
 
@@ -770,6 +836,7 @@ workers:
     # Detailed default security context for logGroomerSidecar for container level
     securityContexts:
       container: {}
+    env: []
 
   waitForMigrations:
     # Whether to create init container to wait for db migrations
@@ -868,9 +935,12 @@ scheduler:
   # container level lifecycle hooks
   containerLifecycleHooks: {}
 
+  # Grace period for tasks to finish after SIGTERM is sent from kubernetes
+  terminationGracePeriodSeconds: 10
+
   # Create ServiceAccount
   serviceAccount:
-    # default value is true
+    # only affect CeleryExecutor, default value is true
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
     automountServiceAccountToken: true
     # Specifies whether a ServiceAccount should be created
@@ -973,6 +1043,7 @@ scheduler:
       container: {}
     # container level lifecycle hooks
     containerLifecycleHooks: {}
+    env: []
 
   waitForMigrations:
     # Whether to create init container to wait for db migrations
@@ -1185,19 +1256,17 @@ migrateDatabaseJob:
   # Disable this if you are using ArgoCD for example
   useHelmHooks: false
   applyCustomEnv: true
+  env: []
 
-# rpcServer support is experimental / dev purpose only and will later be renamed
-_rpcServer:
-  enabled: false
+_apiServer:
 
   # Labels specific to workers objects and pods
   labels: {}
 
-  # Command to use when running the Airflow rpc server (templated).
-  command:
-    - "bash"
-  # Args to use when running the Airflow rpc server (templated).
-  args: ["-c", "exec airflow internal-api"]
+  # Command to use when running the Airflow API server (templated).
+  command: ~
+  # Args to use when running the Airflow API server (templated).
+  args: ["bash", "-c", "exec airflow fastapi-api"]
   env: []
   serviceAccount:
     # default value is true
@@ -1216,8 +1285,8 @@ _rpcServer:
     ## service annotations
     annotations: {}
     ports:
-      - name: rpc-server
-        port: "{{ .Values.ports._rpcServer }}"
+      - name: api-server
+        port: "{{ .Values.ports._apiServer }}"
 
     loadBalancerIP: ~
     ## Limit load balancer source ips to list of CIDRs
@@ -1250,15 +1319,13 @@ _rpcServer:
   # Launch additional containers into the flower pods.
   extraContainers: []
 
-  # Additional network policies as needed (Deprecated - renamed to `webserver.networkPolicy.ingress.from`)
-  extraNetworkPolicies: []
   networkPolicy:
     ingress:
       # Peers for webserver NetworkPolicy ingress
       from: []
       # Ports for webserver NetworkPolicy ingress (if `from` is set)
       ports:
-        - port: "{{ .Values.ports._rpcServer }}"
+        - port: "{{ .Values.ports._apiServer }}"
 
   resources: {}
   #   limits:
@@ -1282,8 +1349,6 @@ _rpcServer:
     periodSeconds: 10
     scheme: HTTP
 
-  # Wait for at most 1 minute (6*10s) for the RPC server container to startup.
-  # livenessProbe kicks in after the first successful startupProbe
   startupProbe:
     timeoutSeconds: 20
     failureThreshold: 6
@@ -1335,6 +1400,32 @@ webserver:
   command: ~
   # Args to use when running the Airflow webserver (templated).
   args: ["bash", "-c", "exec airflow webserver"]
+
+  # Grace period for webserver to finish after SIGTERM is sent from kubernetes
+  terminationGracePeriodSeconds: 30
+
+  # Allow HPA
+  hpa:
+    enabled: false
+
+    # Minimum number of webservers created by HPA
+    minReplicaCount: 1
+
+    # Maximum number of webservers created by HPA
+    maxReplicaCount: 5
+
+    # Specifications for which to use to calculate the desired replica count
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+
+    # Scaling behavior of the target in both Up and Down directions
+    behavior: {}
+
 
   # Create ServiceAccount
   serviceAccount:
@@ -1426,7 +1517,7 @@ webserver:
   extraVolumes: []
   extraVolumeMounts: []
 
-  # This string (can be templated) will be mounted into the Airflow Webserver
+  # This string (templated) will be mounted into the Airflow Webserver
   # as a custom webserver_config.py. You can bake a webserver_config.py in to
   # your image instead or specify a configmap containing the
   # webserver_config.py.
@@ -1632,6 +1723,15 @@ triggerer:
   tolerations: []
   topologySpreadConstraints: []
 
+  #  hostAliases for the triggerer pod
+  hostAliases: []
+  #  - ip: "127.0.0.1"
+  #    hostnames:
+  #      - "foo.local"
+  #  - ip: "10.1.2.3"
+  #    hostnames:
+  #      - "foo.remote"
+
   priorityClassName: ~
 
   # annotations for the triggerer deployment
@@ -1664,6 +1764,8 @@ triggerer:
 
     # container level lifecycle hooks
     containerLifecycleHooks: {}
+
+    env: []
 
   waitForMigrations:
     # Whether to create init container to wait for db migrations
@@ -1845,6 +1947,8 @@ dagProcessor:
     securityContexts:
       container: {}
 
+    env: []
+
   waitForMigrations:
     # Whether to create init container to wait for db migrations
     enabled: true
@@ -1872,6 +1976,13 @@ flower:
     timeoutSeconds: 5
     failureThreshold: 10
     periodSeconds: 5
+
+  # Wait for at most 1 minute (6*10s) for the flower container to startup.
+  # livenessProbe kicks in after the first successful startupProbe
+  startupProbe:
+    timeoutSeconds: 20
+    failureThreshold: 6
+    periodSeconds: 10
 
   # Max number of old replicasets to retain
   revisionHistoryLimit: ~
@@ -2007,6 +2118,9 @@ statsd:
   # Annotations to add to the StatsD Deployment.
   annotations: {}
 
+  # Grace period for statsd to finish after SIGTERM is sent from kubernetes
+  terminationGracePeriodSeconds: 30
+
   # Create ServiceAccount
   serviceAccount:
     # default value is true
@@ -2087,6 +2201,10 @@ pgbouncer:
   auth_type: scram-sha-256
   auth_file: /etc/pgbouncer/users.txt
 
+  # Whether to mount the config secret files at a default location (/etc/pgbouncer/*).
+  # Can be skipped to allow for other means to get the values, e.g. secrets provider class.
+  mountConfigSecret: true
+
   # annotations to be added to the PgBouncer deployment
   annotations: {}
 
@@ -2159,6 +2277,7 @@ pgbouncer:
 
   service:
     extraAnnotations: {}
+    clusterIp: ~
 
   # https://www.pgbouncer.org/config.html
   verbose: 0
@@ -2192,6 +2311,8 @@ pgbouncer:
   #     - name: my-templated-extra-volume
   #       mountPath: "{{ .Values.my_custom_path }}"
   #       readOnly: true
+  # Volumes apply to all pgbouncer containers, while volume mounts apply to the pgbouncer
+  # container itself. Metrics exporter container has its own mounts.
   extraVolumes: []
   extraVolumeMounts: []
 
@@ -2265,6 +2386,15 @@ pgbouncer:
       periodSeconds: 10
       timeoutSeconds: 1
 
+    # Mount additional volumes into the metrics exporter. It can be templated like in the following example:
+    #   extraVolumeMounts:
+    #     - name: my-templated-extra-volume
+    #       mountPath: "{{ .Values.my_custom_path }}"
+    #       readOnly: true
+    extraVolumeMounts: []
+
+  # Labels specific to pgbouncer objects and pods
+  labels: {}
   # Environment variables to add to pgbouncer container
   env: []
 
@@ -2290,6 +2420,14 @@ redis:
     # Annotations to add to worker kubernetes service account.
     annotations: {}
 
+  service:
+    # service type, default: ClusterIP
+    type: "ClusterIP"
+    # If using ClusterIP service type, custom IP address can be specified
+    clusterIP:
+    # If using NodePort service type, custom node port can be specified
+    nodePort:
+
   persistence:
     # Enable persistent volumes
     enabled: true
@@ -2299,6 +2437,8 @@ redis:
     storageClassName:
     # Annotations to add to redis volumes
     annotations: {}
+    # the name of an existing PVC to use
+    existingClaim:
 
   # Configuration for empty dir volume (if redis.persistence.enabled == false)
   # emptyDirConfig:
@@ -2380,6 +2520,22 @@ elasticsearch:
   #   port: ~
   connection: {}
 
+# OpenSearch logging configuration
+opensearch:
+  # Enable opensearch task logging
+  enabled: false
+  # A secret containing the connection
+  secretName: ~
+  # Or an object representing the connection
+  # Example:
+  # connection:
+  #   scheme: ~
+  #   user: ~
+  #   pass: ~
+  #   host: ~
+  #   port: ~
+  connection: {}
+
 # All ports used by chart
 ports:
   flowerUI: 5555
@@ -2391,8 +2547,7 @@ ports:
   statsdScrape: 9102
   pgbouncer: 6543
   pgbouncerScrape: 9127
-  # rpcServer support is experimental / dev purpose only and will later be renamed
-  _rpcServer: 9080
+  _apiServer: 9091
 
 # Define any ResourceQuotas for namespace
 quotas: {}
@@ -2499,10 +2654,10 @@ config:
     executor: '{{ .Values.executor }}'
     # For Airflow 1.10, backward compatibility; moved to [logging] in 2.0
     colored_console_log: 'False'
-    remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
+    remote_logging: '{{- ternary "True" "False" (or .Values.elasticsearch.enabled .Values.opensearch.enabled) }}'
     allowed_deserialization_classes_regexp: ".*"
   logging:
-    remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
+    remote_logging: '{{- ternary "True" "False" (or .Values.elasticsearch.enabled .Values.opensearch.enabled) }}'
     colored_console_log: 'False'
   metrics:
     statsd_on: '{{ ternary "True" "False" .Values.statsd.enabled }}'
@@ -2517,7 +2672,7 @@ config:
     flower_url_prefix: '{{ ternary "" .Values.ingress.flower.path (eq .Values.ingress.flower.path "/") }}'
     worker_concurrency: 16
   scheduler:
-    standalone_dag_processor: '{{ ternary "True" "False" .Values.dagProcessor.enabled }}'
+    standalone_dag_processor: '{{ ternary "True" "False" (or (semverCompare ">=3.0.0" .Values.airflowVersion) (.Values.dagProcessor.enabled | default false)) }}'
     # statsd params included for Airflow 1.10 backward compatibility; moved to [metrics] in 2.0
     statsd_on: '{{ ternary "True" "False" .Values.statsd.enabled }}'
     statsd_port: 9125
@@ -2743,4 +2898,3 @@ logs:
     storageClassName: gp3
     ## the name of an existing PVC to use
     existingClaim:
-

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -224,66 +224,6 @@ ingress:
       # the name of a pre-created Secret containing a TLS private key and certificate
       secretName: ""
 
-  # Configs for the Ingress of the statsd Service
-  statsd:
-    # Enable web ingress resource
-    enabled: false
-
-    # Annotations for the statsd Ingress
-    annotations: {}
-
-    # The path for the statsd Ingress
-    path: "/metrics"
-
-    # The pathType for the above path (used only with Kubernetes v1.19 and above)
-    pathType: "ImplementationSpecific"
-
-    # The hostname for the statsd Ingress (Deprecated - renamed to `ingress.statsd.hosts`)
-    host: ""
-
-    # The hostnames or hosts configuration for the statsd Ingress
-    hosts: []
-    #   # The hostname for the statsd Ingress (templated)
-    # - name: ""
-    #   tls:
-    #     # Enable TLS termination for the statsd Ingress
-    #     enabled: false
-    #     # the name of a pre-created Secret containing a TLS private key and certificate
-    #     secretName: ""
-
-    # The Ingress Class for the statsd Ingress (used only with Kubernetes v1.19 and above)
-    ingressClassName: ""
-
-  # Configs for the Ingress of the pgbouncer Service
-  pgbouncer:
-    # Enable web ingress resource
-    enabled: false
-
-    # Annotations for the pgbouncer Ingress
-    annotations: {}
-
-    # The path for the pgbouncer Ingress
-    path: "/metrics"
-
-    # The pathType for the above path (used only with Kubernetes v1.19 and above)
-    pathType: "ImplementationSpecific"
-
-    # The hostname for the pgbouncer Ingress (Deprecated - renamed to `ingress.pgbouncer.hosts`)
-    host: ""
-
-    # The hostnames or hosts configuration for the pgbouncer Ingress
-    hosts: []
-    #   # The hostname for the statsd Ingress (templated)
-    # - name: ""
-    #   tls:
-    #     # Enable TLS termination for the pgbouncer Ingress
-    #     enabled: false
-    #     # the name of a pre-created Secret containing a TLS private key and certificate
-    #     secretName: ""
-
-    # The Ingress Class for the pgbouncer Ingress (used only with Kubernetes v1.19 and above)
-    ingressClassName: ""
-
 # Network policy configuration
 networkPolicies:
   # Enabled network policies

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -368,7 +368,7 @@ enableBuiltInSecretEnvVars:
   AIRFLOW__CELERY__BROKER_URL: true
   AIRFLOW__ELASTICSEARCH__HOST: true
   AIRFLOW__ELASTICSEARCH__ELASTICSEARCH_HOST: true
-  AIRFLOW__OPENSEARCH__HOST: true
+  # AIRFLOW__OPENSEARCH__HOST: true
 
 # Priority Classes that will be installed by charts.
 # Ideally, there should be an entry for dagProcessor, flower,
@@ -836,7 +836,6 @@ workers:
     # Detailed default security context for logGroomerSidecar for container level
     securityContexts:
       container: {}
-    env: []
 
   waitForMigrations:
     # Whether to create init container to wait for db migrations
@@ -845,8 +844,6 @@ workers:
     # Detailed default security context for waitForMigrations for container level
     securityContexts:
       container: {}
-
-  env: []
 
   volumeClaimTemplates: []
   # Additional volumeClaimTemplates needed.
@@ -934,9 +931,6 @@ scheduler:
 
   # container level lifecycle hooks
   containerLifecycleHooks: {}
-
-  # Grace period for tasks to finish after SIGTERM is sent from kubernetes
-  terminationGracePeriodSeconds: 10
 
   # Create ServiceAccount
   serviceAccount:
@@ -1043,7 +1037,6 @@ scheduler:
       container: {}
     # container level lifecycle hooks
     containerLifecycleHooks: {}
-    env: []
 
   waitForMigrations:
     # Whether to create init container to wait for db migrations
@@ -1256,7 +1249,6 @@ migrateDatabaseJob:
   # Disable this if you are using ArgoCD for example
   useHelmHooks: false
   applyCustomEnv: true
-  env: []
 
 _apiServer:
 
@@ -1286,7 +1278,7 @@ _apiServer:
     annotations: {}
     ports:
       - name: api-server
-        port: "{{ .Values.ports._apiServer }}"
+        port: "9091"
 
     loadBalancerIP: ~
     ## Limit load balancer source ips to list of CIDRs
@@ -1325,7 +1317,7 @@ _apiServer:
       from: []
       # Ports for webserver NetworkPolicy ingress (if `from` is set)
       ports:
-        - port: "{{ .Values.ports._apiServer }}"
+        - port: "9091"
 
   resources: {}
   #   limits:
@@ -1400,31 +1392,6 @@ webserver:
   command: ~
   # Args to use when running the Airflow webserver (templated).
   args: ["bash", "-c", "exec airflow webserver"]
-
-  # Grace period for webserver to finish after SIGTERM is sent from kubernetes
-  terminationGracePeriodSeconds: 30
-
-  # Allow HPA
-  hpa:
-    enabled: false
-
-    # Minimum number of webservers created by HPA
-    minReplicaCount: 1
-
-    # Maximum number of webservers created by HPA
-    maxReplicaCount: 5
-
-    # Specifications for which to use to calculate the desired replica count
-    metrics:
-      - type: Resource
-        resource:
-          name: cpu
-          target:
-            type: Utilization
-            averageUtilization: 80
-
-    # Scaling behavior of the target in both Up and Down directions
-    behavior: {}
 
 
   # Create ServiceAccount
@@ -1723,15 +1690,6 @@ triggerer:
   tolerations: []
   topologySpreadConstraints: []
 
-  #  hostAliases for the triggerer pod
-  hostAliases: []
-  #  - ip: "127.0.0.1"
-  #    hostnames:
-  #      - "foo.local"
-  #  - ip: "10.1.2.3"
-  #    hostnames:
-  #      - "foo.remote"
-
   priorityClassName: ~
 
   # annotations for the triggerer deployment
@@ -1764,8 +1722,6 @@ triggerer:
 
     # container level lifecycle hooks
     containerLifecycleHooks: {}
-
-    env: []
 
   waitForMigrations:
     # Whether to create init container to wait for db migrations
@@ -1977,13 +1933,6 @@ flower:
     failureThreshold: 10
     periodSeconds: 5
 
-  # Wait for at most 1 minute (6*10s) for the flower container to startup.
-  # livenessProbe kicks in after the first successful startupProbe
-  startupProbe:
-    timeoutSeconds: 20
-    failureThreshold: 6
-    periodSeconds: 10
-
   # Max number of old replicasets to retain
   revisionHistoryLimit: ~
 
@@ -2118,9 +2067,6 @@ statsd:
   # Annotations to add to the StatsD Deployment.
   annotations: {}
 
-  # Grace period for statsd to finish after SIGTERM is sent from kubernetes
-  terminationGracePeriodSeconds: 30
-
   # Create ServiceAccount
   serviceAccount:
     # default value is true
@@ -2201,10 +2147,6 @@ pgbouncer:
   auth_type: scram-sha-256
   auth_file: /etc/pgbouncer/users.txt
 
-  # Whether to mount the config secret files at a default location (/etc/pgbouncer/*).
-  # Can be skipped to allow for other means to get the values, e.g. secrets provider class.
-  mountConfigSecret: true
-
   # annotations to be added to the PgBouncer deployment
   annotations: {}
 
@@ -2277,7 +2219,6 @@ pgbouncer:
 
   service:
     extraAnnotations: {}
-    clusterIp: ~
 
   # https://www.pgbouncer.org/config.html
   verbose: 0
@@ -2386,15 +2327,6 @@ pgbouncer:
       periodSeconds: 10
       timeoutSeconds: 1
 
-    # Mount additional volumes into the metrics exporter. It can be templated like in the following example:
-    #   extraVolumeMounts:
-    #     - name: my-templated-extra-volume
-    #       mountPath: "{{ .Values.my_custom_path }}"
-    #       readOnly: true
-    extraVolumeMounts: []
-
-  # Labels specific to pgbouncer objects and pods
-  labels: {}
   # Environment variables to add to pgbouncer container
   env: []
 
@@ -2420,14 +2352,6 @@ redis:
     # Annotations to add to worker kubernetes service account.
     annotations: {}
 
-  service:
-    # service type, default: ClusterIP
-    type: "ClusterIP"
-    # If using ClusterIP service type, custom IP address can be specified
-    clusterIP:
-    # If using NodePort service type, custom node port can be specified
-    nodePort:
-
   persistence:
     # Enable persistent volumes
     enabled: true
@@ -2437,8 +2361,6 @@ redis:
     storageClassName:
     # Annotations to add to redis volumes
     annotations: {}
-    # the name of an existing PVC to use
-    existingClaim:
 
   # Configuration for empty dir volume (if redis.persistence.enabled == false)
   # emptyDirConfig:
@@ -2547,7 +2469,7 @@ ports:
   statsdScrape: 9102
   pgbouncer: 6543
   pgbouncerScrape: 9127
-  _apiServer: 9091
+  # _apiServer: 9091
 
 # Define any ResourceQuotas for namespace
 quotas: {}


### PR DESCRIPTION
# **Problem:**

- The current version of apache airflow 2.9.3 is out of date and is running into some crashing issues in production.

# **Solution:**

- Update the deployment images and values for apache airflow to follow the latest available at https://github.com/apache/airflow/blob/main/chart/values.yaml
- Remove invalid configuration that cannot be applied in the values.yaml file since apache has not released a new helm chart version, however, the updated values.yaml file is sufficient for updating the deployed containers.

# **Testing:**

- I deployed this branch to the `dpe-k8-sandbox` cluster and verified that 1) The instances could start up as expected from nothing deployed to the cluster, and 2) I could run a DAG within the apache airflow UI.

![image](https://github.com/user-attachments/assets/12754468-aa02-4693-9b9f-9c065fa54e7e)

