### PR TITLE
[PORTALS-3539] Support enabling cors for S3 bucket

### DIFF
--- a/deployments/stacks/dpe-k8s/main.tf
+++ b/deployments/stacks/dpe-k8s/main.tf
@@ -54,4 +54,5 @@ module "synapse_dataset_to_crossiant_metadata" {
   cluster_name = var.cluster_name
   cluster_oidc_provider_arn = module.sage-aws-eks.cluster_oidc_provider_arn
   public_access = true
+  enable_cors = true
 }

--- a/modules/s3-bucket/main.tf
+++ b/modules/s3-bucket/main.tf
@@ -41,6 +41,8 @@ resource "aws_s3_bucket_policy" "my_bucket_policy" {
   count = var.public_access ? 1 : 0
   bucket = aws_s3_bucket.bucket.bucket
 
+  depends_on = [ aws_s3_bucket_acl.bucket_acl, aws_s3_bucket_public_access_block.access_block ]
+
   policy = jsonencode({
     Version = "2012-10-17",
     Statement = [
@@ -52,6 +54,16 @@ resource "aws_s3_bucket_policy" "my_bucket_policy" {
       },
     ],
   })
+}
+
+resource "aws_s3_bucket_cors_configuration" "example" {
+  count = var.enable_cors ? 1 : 0
+  bucket = aws_s3_bucket.bucket.id
+
+  cors_rule {
+    allowed_methods = ["GET"]
+    allowed_origins = ["*"]
+  }
 }
 
 resource "aws_s3_bucket_versioning" "versioning" {

--- a/modules/s3-bucket/main.tf
+++ b/modules/s3-bucket/main.tf
@@ -56,7 +56,7 @@ resource "aws_s3_bucket_policy" "my_bucket_policy" {
   })
 }
 
-resource "aws_s3_bucket_cors_configuration" "example" {
+resource "aws_s3_bucket_cors_configuration" "cors" {
   count = var.enable_cors ? 1 : 0
   bucket = aws_s3_bucket.bucket.id
 

--- a/modules/s3-bucket/variables.tf
+++ b/modules/s3-bucket/variables.tf
@@ -37,3 +37,9 @@ variable "public_access" {
   type        = bool
   default     = false
 }
+
+variable "enable_cors" {
+  description = "Enable CORS on the bucket"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
# **Problem:**

- CORS needs to be enabled on the S3 bucket in order to be surfaced in any portal as detailed in this message: https://sagebionetworks.jira.com/browse/PORTALS-3539?focusedCommentId=245688

# **Solution:**

- Creating a resource defined in this document: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_cors_configuration to support creating CORS rules for the bucket
- Setting the Croissant S3 bucket to use CORS

# **Testing:**

- Will be reviewing the terraform plan and apply
