### PR TITLE
[DPE-1266] Improve responsiveness of webserver pod

### DIFF
--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -681,14 +681,13 @@ workers:
     #   cpu: 100m
     #   memory: 128Mi
 
-
-  resources: {}
-  #  limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  #  requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  resources:
+    limits:
+     cpu: 100m
+     memory: 128Mi
+    requests:
+     cpu: 100m
+     memory: 128Mi
 
   # Grace period for tasks to finish after SIGTERM is sent from kubernetes
   terminationGracePeriodSeconds: 600
@@ -896,13 +895,13 @@ scheduler:
       maxUnavailable: 1
       # minAvailable: 1
 
-  resources: {}
-  #  limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  #  requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  resources:
+    limits:
+     cpu: 100m
+     memory: 128Mi
+    requests:
+     cpu: 100m
+     memory: 128Mi
 
   # This setting tells kubernetes that its ok to evict
   # when it wants to scale a node down.
@@ -966,12 +965,12 @@ scheduler:
     # Number of days to retain logs
     retentionDays: 15
     resources: {}
-    #  limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    #  requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+      limits:
+       cpu: 100m
+       memory: 128Mi
+      requests:
+       cpu: 100m
+       memory: 128Mi
     # Detailed default security context for logGroomerSidecar for container level
     securityContexts:
       container: {}
@@ -1087,13 +1086,13 @@ createUserJob:
 
   env: []
 
-  resources: {}
-  #  limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  #  requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  resources:
+     limits:
+       cpu: 100m
+       memory: 128Mi
+     requests:
+       cpu: 100m
+       memory: 128Mi
 
 # Airflow database migration job settings
 migrateDatabaseJob:
@@ -1151,13 +1150,13 @@ migrateDatabaseJob:
     # Annotations to add to migrate database job kubernetes service account.
     annotations: {}
 
-  resources: {}
-  #  limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  #  requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  resources:
+    limits:
+     cpu: 100m
+     memory: 128Mi
+    requests:
+     cpu: 100m
+     memory: 128Mi
 
   # Launch additional containers into database migration job
   extraContainers: []
@@ -1259,13 +1258,13 @@ _apiServer:
       ports:
         - port: "9091"
 
-  resources: {}
-  #   limits:
-  #     cpu: 100m
-  #     memory: 128Mi
-  #   requests:
-  #     cpu: 100m
-  #     memory: 128Mi
+  resources:
+     limits:
+       cpu: 100m
+       memory: 128Mi
+     requests:
+       cpu: 100m
+       memory: 128Mi
 
   livenessProbe:
     initialDelaySeconds: 15
@@ -1386,13 +1385,13 @@ webserver:
       ports:
         - port: "{{ .Values.ports.airflowUI }}"
 
-  resources: {}
-  #   limits:
-  #     cpu: 100m
-  #     memory: 128Mi
-  #   requests:
-  #     cpu: 100m
-  #     memory: 128Mi
+  resources:
+     limits:
+       cpu: 100m
+       memory: 128Mi
+     requests:
+       cpu: 100m
+       memory: 128Mi
 
   # Create initial user.
   defaultUser:
@@ -1577,13 +1576,13 @@ triggerer:
     # Annotations to add to triggerer volumes
     annotations: {}
 
-  resources: {}
-  #  limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  #  requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  resources:
+     limits:
+       cpu: 100m
+       memory: 128Mi
+     requests:
+       cpu: 100m
+       memory: 128Mi
 
   # Grace period for triggerer to finish after SIGTERM is sent from kubernetes
   terminationGracePeriodSeconds: 60
@@ -1767,13 +1766,13 @@ dagProcessor:
   # container level lifecycle hooks
   containerLifecycleHooks: {}
 
-  resources: {}
-  #  limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  #  requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  resources:
+    limits:
+     cpu: 100m
+     memory: 128Mi
+    requests:
+     cpu: 100m
+     memory: 128Mi
 
   # Grace period for dag processor to finish after SIGTERM is sent from kubernetes
   terminationGracePeriodSeconds: 60
@@ -1833,13 +1832,13 @@ dagProcessor:
     args: ["bash", "/clean-logs"]
     # Number of days to retain logs
     retentionDays: 15
-    resources: {}
-    #  limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    #  requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+    resources:
+      limits:
+       cpu: 100m
+       memory: 128Mi
+      requests:
+       cpu: 100m
+       memory: 128Mi
     securityContexts:
       container: {}
 
@@ -1895,13 +1894,13 @@ flower:
       ports:
         - port: "{{ .Values.ports.flowerUI }}"
 
-  resources: {}
-  #   limits:
-  #     cpu: 100m
-  #     memory: 128Mi
-  #   requests:
-  #     cpu: 100m
-  #     memory: 128Mi
+  resources:
+    limits:
+     cpu: 100m
+     memory: 128Mi
+    requests:
+     cpu: 100m
+     memory: 128Mi
 
   # When not set, the values defined in the global securityContext will be used
   securityContext: {}
@@ -2221,13 +2220,13 @@ pgbouncer:
         command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 120"]
 
   metricsExporterSidecar:
-    resources: {}
-    #  limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    #  requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+    resources:
+      limits:
+       cpu: 100m
+       memory: 128Mi
+      requests:
+       cpu: 100m
+       memory: 128Mi
     sslmode: "disable"
 
     # supply the name of existing secret with PGBouncer connection URI containing
@@ -2305,13 +2304,13 @@ redis:
   #   sizeLimit: 1Gi
   #   medium: Memory
 
-  resources: {}
-  #  limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  #  requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  resources:
+    limits:
+     cpu: 100m
+     memory: 128Mi
+    requests:
+     cpu: 100m
+     memory: 128Mi
 
   # If set use as redis secret. Make sure to also set data.brokerUrlSecretName value.
   passwordSecretName: ~
@@ -2734,12 +2733,12 @@ dags:
     #   medium: Memory
 
     resources: {}
-    #  limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    #  requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+      limits:
+       cpu: 100m
+       memory: 128Mi
+      requests:
+       cpu: 100m
+       memory: 128Mi
 
 logs:
   # Configuration for empty dir volume (if logs.persistence.enabled == false)

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -1472,6 +1472,7 @@ webserver:
   # Select certain nodes for airflow webserver pods.
   nodeSelector: {}
   priorityClassName: ~
+  affinity:
   # default webserver affinity is:
    podAntiAffinity:
      preferredDuringSchedulingIgnoredDuringExecution:

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -1474,14 +1474,14 @@ webserver:
   priorityClassName: ~
   affinity: {}
   # default webserver affinity is:
-  #  podAntiAffinity:
-  #    preferredDuringSchedulingIgnoredDuringExecution:
-  #    - podAffinityTerm:
-  #        labelSelector:
-  #          matchLabels:
-  #            component: webserver
-  #        topologyKey: kubernetes.io/hostname
-  #      weight: 100
+   podAntiAffinity:
+     preferredDuringSchedulingIgnoredDuringExecution:
+     - podAffinityTerm:
+         labelSelector:
+           matchLabels:
+             component: webserver
+         topologyKey: kubernetes.io/hostname
+       weight: 100
   tolerations: []
   topologySpreadConstraints: []
 

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -673,7 +673,7 @@ workers:
   kerberosInitContainer:
     # Enable kerberos init container
     enabled: false
-    resources: {}
+    resources:
     #  limits:
     #   cpu: 100m
     #   memory: 128Mi

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -1472,7 +1472,6 @@ webserver:
   # Select certain nodes for airflow webserver pods.
   nodeSelector: {}
   priorityClassName: ~
-  affinity: {}
   # default webserver affinity is:
    podAntiAffinity:
      preferredDuringSchedulingIgnoredDuringExecution:

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -657,13 +657,13 @@ workers:
   kerberosSidecar:
     # Enable kerberos sidecar
     enabled: false
-    resources:
+    resources: {}
     #  limits:
     #   cpu: 100m
     #   memory: 128Mi
-     requests:
-      cpu: 100m
-      memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
     # Detailed default security context for kerberosSidecar for container level
     securityContexts:
       container: {}
@@ -673,21 +673,21 @@ workers:
   kerberosInitContainer:
     # Enable kerberos init container
     enabled: false
-    resources:
+    resources: {}
     #  limits:
     #   cpu: 100m
     #   memory: 128Mi
-      requests:
-       cpu: 100m
-       memory: 128Mi
+    #  requests:
+    #   cpu: 100m
+    #   memory: 128Mi
 
-  resources:
+  resources: {}
   #  limits:
   #   cpu: 100m
   #   memory: 128Mi
-    requests:
-     cpu: 100m
-     memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
 
   # Grace period for tasks to finish after SIGTERM is sent from kubernetes
   terminationGracePeriodSeconds: 600
@@ -1766,13 +1766,13 @@ dagProcessor:
   # container level lifecycle hooks
   containerLifecycleHooks: {}
 
-  resources:
+  resources: {}
   #  limits:
   #   cpu: 100m
   #   memory: 128Mi
-    requests:
-     cpu: 100m
-     memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
 
   # Grace period for dag processor to finish after SIGTERM is sent from kubernetes
   terminationGracePeriodSeconds: 60
@@ -1894,13 +1894,13 @@ flower:
       ports:
         - port: "{{ .Values.ports.flowerUI }}"
 
-  resources:
+  resources: {}
   #  limits:
   #   cpu: 100m
   #   memory: 128Mi
-    requests:
-     cpu: 100m
-     memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
 
   # When not set, the values defined in the global securityContext will be used
   securityContext: {}
@@ -2444,13 +2444,13 @@ cleanup:
   # Labels specific to cleanup objects and pods
   labels: {}
 
-  resources:
+  resources: {}
   #  limits:
   #   cpu: 100m
   #   memory: 128Mi
-    requests:
-     cpu: 100m
-     memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
 
   # Create ServiceAccount
   serviceAccount:

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -677,14 +677,14 @@ workers:
     #  limits:
     #   cpu: 100m
     #   memory: 128Mi
-    #  requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+      requests:
+       cpu: 100m
+       memory: 128Mi
 
   resources:
-    limits:
-     cpu: 100m
-     memory: 128Mi
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
     requests:
      cpu: 100m
      memory: 128Mi
@@ -765,13 +765,13 @@ workers:
     args: ["bash", "/clean-logs"]
     # Number of days to retain logs
     retentionDays: 15
-    resources: {}
+    resources:
     #  limits:
     #   cpu: 100m
     #   memory: 128Mi
-    #  requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+      requests:
+       cpu: 100m
+       memory: 128Mi
     # Detailed default security context for logGroomerSidecar for container level
     securityContexts:
       container: {}
@@ -896,9 +896,9 @@ scheduler:
       # minAvailable: 1
 
   resources:
-    limits:
-     cpu: 100m
-     memory: 128Mi
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
     requests:
      cpu: 100m
      memory: 128Mi
@@ -964,10 +964,10 @@ scheduler:
     args: ["bash", "/clean-logs"]
     # Number of days to retain logs
     retentionDays: 15
-    resources: {}
-      limits:
-       cpu: 100m
-       memory: 128Mi
+    resources:
+    #  limits:
+    #   cpu: 100m
+    #   memory: 128Mi
       requests:
        cpu: 100m
        memory: 128Mi
@@ -1087,12 +1087,12 @@ createUserJob:
   env: []
 
   resources:
-     limits:
-       cpu: 100m
-       memory: 128Mi
-     requests:
-       cpu: 100m
-       memory: 128Mi
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+    requests:
+     cpu: 100m
+     memory: 128Mi
 
 # Airflow database migration job settings
 migrateDatabaseJob:
@@ -1151,9 +1151,9 @@ migrateDatabaseJob:
     annotations: {}
 
   resources:
-    limits:
-     cpu: 100m
-     memory: 128Mi
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
     requests:
      cpu: 100m
      memory: 128Mi
@@ -1259,12 +1259,12 @@ _apiServer:
         - port: "9091"
 
   resources:
-     limits:
-       cpu: 100m
-       memory: 128Mi
-     requests:
-       cpu: 100m
-       memory: 128Mi
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+    requests:
+     cpu: 100m
+     memory: 128Mi
 
   livenessProbe:
     initialDelaySeconds: 15
@@ -1386,12 +1386,12 @@ webserver:
         - port: "{{ .Values.ports.airflowUI }}"
 
   resources:
-     limits:
-       cpu: 100m
-       memory: 128Mi
-     requests:
-       cpu: 100m
-       memory: 128Mi
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+    requests:
+     cpu: 100m
+     memory: 128Mi
 
   # Create initial user.
   defaultUser:
@@ -1577,12 +1577,12 @@ triggerer:
     annotations: {}
 
   resources:
-     limits:
-       cpu: 100m
-       memory: 128Mi
-     requests:
-       cpu: 100m
-       memory: 128Mi
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+    requests:
+     cpu: 100m
+     memory: 128Mi
 
   # Grace period for triggerer to finish after SIGTERM is sent from kubernetes
   terminationGracePeriodSeconds: 60
@@ -1648,13 +1648,13 @@ triggerer:
     args: ["bash", "/clean-logs"]
     # Number of days to retain logs
     retentionDays: 15
-    resources: {}
+    resources:
     #  limits:
     #   cpu: 100m
     #   memory: 128Mi
-    #  requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+      requests:
+       cpu: 100m
+       memory: 128Mi
     # Detailed default security context for logGroomerSidecar for container level
     securityContexts:
       container: {}
@@ -1767,9 +1767,9 @@ dagProcessor:
   containerLifecycleHooks: {}
 
   resources:
-    limits:
-     cpu: 100m
-     memory: 128Mi
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
     requests:
      cpu: 100m
      memory: 128Mi
@@ -1833,9 +1833,9 @@ dagProcessor:
     # Number of days to retain logs
     retentionDays: 15
     resources:
-      limits:
-       cpu: 100m
-       memory: 128Mi
+    #  limits:
+    #   cpu: 100m
+    #   memory: 128Mi
       requests:
        cpu: 100m
        memory: 128Mi
@@ -1895,9 +1895,9 @@ flower:
         - port: "{{ .Values.ports.flowerUI }}"
 
   resources:
-    limits:
-     cpu: 100m
-     memory: 128Mi
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
     requests:
      cpu: 100m
      memory: 128Mi
@@ -2221,9 +2221,9 @@ pgbouncer:
 
   metricsExporterSidecar:
     resources:
-      limits:
-       cpu: 100m
-       memory: 128Mi
+    #  limits:
+    #   cpu: 100m
+    #   memory: 128Mi
       requests:
        cpu: 100m
        memory: 128Mi
@@ -2305,9 +2305,9 @@ redis:
   #   medium: Memory
 
   resources:
-    limits:
-     cpu: 100m
-     memory: 128Mi
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
     requests:
      cpu: 100m
      memory: 128Mi
@@ -2445,12 +2445,12 @@ cleanup:
   labels: {}
 
   resources:
-   limits:
-    cpu: 1000m
-    memory: 512Mi
-   requests:
-    cpu: 100m
-    memory: 128Mi
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+    requests:
+     cpu: 100m
+     memory: 128Mi
 
   # Create ServiceAccount
   serviceAccount:
@@ -2732,13 +2732,13 @@ dags:
     #   sizeLimit: 1Gi
     #   medium: Memory
 
-    resources: {}
-      limits:
-       cpu: 100m
-       memory: 128Mi
-      requests:
-       cpu: 100m
-       memory: 128Mi
+  resources:
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+    requests:
+     cpu: 100m
+     memory: 128Mi
 
 logs:
   # Configuration for empty dir volume (if logs.persistence.enabled == false)

--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -841,7 +841,7 @@ scheduler:
 
   # Airflow 2.0 allows users to run multiple schedulers,
   # However this feature is only recommended for MySQL 8+ and Postgres
-  replicas: 1
+  replicas: 2
   # Max number of old replicasets to retain
   revisionHistoryLimit: ~
 
@@ -1324,7 +1324,7 @@ webserver:
     scheme: HTTP
 
   # Number of webservers
-  replicas: 1
+  replicas: 2
   # Max number of old replicasets to retain
   revisionHistoryLimit: ~
 


### PR DESCRIPTION
# **Problem:**

I'm seeing issues with lack of response either from the webserver or the scheduler for the Airflow namespace when trying to unpause and monitor Airflow DAGs:

<img width="1135" alt="image" src="https://github.com/user-attachments/assets/936baf9d-6650-48f9-9fdd-68f2815b1346" />

When unpausing a DAG, it gets hung up and the connection to the port closes. Sometimes ending up in a perpetual restart loop:

<img width="215" alt="image" src="https://github.com/user-attachments/assets/973fddb0-136f-450f-94c1-71f1acc71cf9" />

# **Solution:**

Attempt to improve the responsiveness by:
- [x] upping the replica count
- [x] ensuring the webserver instances end up on different nodes
- [x] setting a memory and CPU resource allotment for requests

# **Testing:**
