### PR TITLE
[SYNPY-1587] Adds AWS API Gateway & SQS modules

### DIFF
--- a/deployments/stacks/dpe-k8s/main.tf
+++ b/deployments/stacks/dpe-k8s/main.tf
@@ -57,15 +57,13 @@ module "synapse_dataset_to_crossiant_metadata" {
   enable_cors = true
 }
 
-module "synapse-webhook-test" {
+module "synapse-sqs-test" {
   source = "../../../modules/aws-sqs"
   environment = var.cluster_name == "dpe-k8s-sandbox" ? "sandbox" : "dev"
-  name = "synapse-webhook"
-  queue_name = "synapse-webhook-queue"
-  namespace = "sqs-test"
+  name = "synapse-sqs-test"
   aws_account_id = var.aws_account_id
   aws_region = var.region
-  ack_controller_role_arn = module.sage-aws-eks.cluster_oidc_provider_arn
+  cluster_oidc_provider_arn = module.sage-aws-eks.cluster_oidc_provider_arn
   
   tags = {
     Environment = var.cluster_name

--- a/deployments/stacks/dpe-k8s/main.tf
+++ b/deployments/stacks/dpe-k8s/main.tf
@@ -57,17 +57,34 @@ module "synapse_dataset_to_crossiant_metadata" {
   enable_cors = true
 }
 
-module "synapse-sqs-test" {
+module "synapse-webhook-api-gateway" {
+  source = "../../../modules/aws-api-gateway"
+  environment = var.cluster_name == "dpe-k8s-sandbox" ? "sandbox" : "dev"
+  name = "synapse-webhook-api-gateway"
+}
+
+module "synapse-sqs-create-queue" {
   source = "../../../modules/aws-sqs"
   environment = var.cluster_name == "dpe-k8s-sandbox" ? "sandbox" : "dev"
-  name = "synapse-sqs-test"
+  name = "synapse-sqs-create-queue"
   aws_account_id = var.aws_account_id
   aws_region = var.region
   cluster_oidc_provider_arn = module.sage-aws-eks.cluster_oidc_provider_arn
   
-  tags = {
-    Environment = var.cluster_name
-    Application = "synapse"
-    ManagedBy   = "terraform"
-  }
+  # API Gateway integration
+  api_gateway_id = module.api_gateway.api_id
+  route_path = "/create"
+}
+
+module "synapse-sqs-delete-queue" {
+  source = "../../../modules/aws-sqs"
+  environment = var.cluster_name == "dpe-k8s-sandbox" ? "sandbox" : "dev"
+  name = "synapse-sqs-delete-queue"
+  aws_account_id = var.aws_account_id
+  aws_region = var.region
+  cluster_oidc_provider_arn = module.sage-aws-eks.cluster_oidc_provider_arn
+  
+  # API Gateway integration
+  api_gateway_id = module.api_gateway.api_id
+  route_path = "/delete"
 }

--- a/deployments/stacks/dpe-k8s/main.tf
+++ b/deployments/stacks/dpe-k8s/main.tf
@@ -63,6 +63,7 @@ module "synapse-webhook-test" {
   name = "synapse-webhook-test"
   queue_name = "synapse-webhook-test"
   namespace = "sqs-test"
+  aws_account_id = var.aws_account_id
   aws_region = var.region
   ack_controller_role_arn = module.sage-aws-eks.cluster_oidc_provider_arn
 }

--- a/deployments/stacks/dpe-k8s/main.tf
+++ b/deployments/stacks/dpe-k8s/main.tf
@@ -59,11 +59,17 @@ module "synapse_dataset_to_crossiant_metadata" {
 
 module "synapse-webhook-test" {
   source = "../../../modules/aws-sqs"
-  environment = "dev"
-  name = "synapse-webhook-test"
-  queue_name = "synapse-webhook-test"
+  environment = var.cluster_name == "dpe-k8s-sandbox" ? "sandbox" : "dev"
+  name = "synapse-webhook"
+  queue_name = "synapse-webhook-queue"
   namespace = "sqs-test"
   aws_account_id = var.aws_account_id
   aws_region = var.region
   ack_controller_role_arn = module.sage-aws-eks.cluster_oidc_provider_arn
+  
+  tags = {
+    Environment = var.cluster_name
+    Application = "synapse"
+    ManagedBy   = "terraform"
+  }
 }

--- a/deployments/stacks/dpe-k8s/main.tf
+++ b/deployments/stacks/dpe-k8s/main.tf
@@ -56,3 +56,13 @@ module "synapse_dataset_to_crossiant_metadata" {
   public_access = true
   enable_cors = true
 }
+
+module "synapse-webhook-test" {
+  source = "../../../modules/webhook-test-api"
+  environment = "dev"
+  name = "synapse-webhook-test"
+  queue_name = "synapse-webhook-test"
+  namespace = "sqs-test"
+  aws_region = var.region
+  ack_controller_role_arn = module.sage-aws-eks.cluster_oidc_provider_arn
+}

--- a/deployments/stacks/dpe-k8s/main.tf
+++ b/deployments/stacks/dpe-k8s/main.tf
@@ -57,36 +57,3 @@ module "synapse_dataset_to_crossiant_metadata" {
   enable_cors = true
 }
 
-module "synapse-webhook-api-gateway" {
-  source = "../../../modules/aws-api-gateway"
-  environment = var.cluster_name == "dpe-k8s-sandbox" ? "sandbox" : "dev"
-  name = "synapse-webhook-api-gateway"
-}
-
-module "synapse-sqs-create-queue" {
-  source = "../../../modules/aws-sqs"
-  environment = var.cluster_name == "dpe-k8s-sandbox" ? "sandbox" : "dev"
-  name = "synapse-sqs-create-queue"
-  aws_account_id = var.aws_account_id
-  aws_region = var.region
-  cluster_oidc_provider_arn = module.sage-aws-eks.cluster_oidc_provider_arn
-  
-  # API Gateway integration
-  enable_api_gateway_integration = true
-  api_gateway_id = module.synapse-webhook-api-gateway.api_id
-  route_path = "/create"
-}
-
-module "synapse-sqs-delete-queue" {
-  source = "../../../modules/aws-sqs"
-  environment = var.cluster_name == "dpe-k8s-sandbox" ? "sandbox" : "dev"
-  name = "synapse-sqs-delete-queue"
-  aws_account_id = var.aws_account_id
-  aws_region = var.region
-  cluster_oidc_provider_arn = module.sage-aws-eks.cluster_oidc_provider_arn
-  
-  # API Gateway integration
-  enable_api_gateway_integration = true
-  api_gateway_id = module.synapse-webhook-api-gateway.api_id
-  route_path = "/delete"
-}

--- a/deployments/stacks/dpe-k8s/main.tf
+++ b/deployments/stacks/dpe-k8s/main.tf
@@ -72,7 +72,7 @@ module "synapse-sqs-create-queue" {
   cluster_oidc_provider_arn = module.sage-aws-eks.cluster_oidc_provider_arn
   
   # API Gateway integration
-  api_gateway_id = module.api_gateway.api_id
+  api_gateway_id = module.synapse-webhook-api-gateway.api_id
   route_path = "/create"
 }
 
@@ -85,6 +85,6 @@ module "synapse-sqs-delete-queue" {
   cluster_oidc_provider_arn = module.sage-aws-eks.cluster_oidc_provider_arn
   
   # API Gateway integration
-  api_gateway_id = module.api_gateway.api_id
+  api_gateway_id = module.synapse-webhook-api-gateway.api_id
   route_path = "/delete"
 }

--- a/deployments/stacks/dpe-k8s/main.tf
+++ b/deployments/stacks/dpe-k8s/main.tf
@@ -72,6 +72,7 @@ module "synapse-sqs-create-queue" {
   cluster_oidc_provider_arn = module.sage-aws-eks.cluster_oidc_provider_arn
   
   # API Gateway integration
+  enable_api_gateway_integration = true
   api_gateway_id = module.synapse-webhook-api-gateway.api_id
   route_path = "/create"
 }
@@ -85,6 +86,7 @@ module "synapse-sqs-delete-queue" {
   cluster_oidc_provider_arn = module.sage-aws-eks.cluster_oidc_provider_arn
   
   # API Gateway integration
+  enable_api_gateway_integration = true
   api_gateway_id = module.synapse-webhook-api-gateway.api_id
   route_path = "/delete"
 }

--- a/deployments/stacks/dpe-k8s/main.tf
+++ b/deployments/stacks/dpe-k8s/main.tf
@@ -58,7 +58,7 @@ module "synapse_dataset_to_crossiant_metadata" {
 }
 
 module "synapse-webhook-test" {
-  source = "../../../modules/webhook-test-api"
+  source = "../../../modules/aws-sqs"
   environment = "dev"
   name = "synapse-webhook-test"
   queue_name = "synapse-webhook-test"

--- a/deployments/stacks/dpe-k8s/outputs.tf
+++ b/deployments/stacks/dpe-k8s/outputs.tf
@@ -53,5 +53,5 @@ output "smtp_password" {
 
 output "synapse_webhook_url" {
   description = "The URL to use for Synapse webhook registration"
-  value       = module.synapse-sqs-test.api_gateway_url
+  value       = "${module.synapse-webhook-api-gateway.api_endpoint}/create"
 }

--- a/deployments/stacks/dpe-k8s/outputs.tf
+++ b/deployments/stacks/dpe-k8s/outputs.tf
@@ -50,8 +50,3 @@ output "smtp_password" {
   sensitive = true
   value     = length(module.sage-aws-ses) > 0 ? module.sage-aws-ses[0].smtp_password : ""
 }
-
-output "synapse_webhook_url" {
-  description = "The URL to use for Synapse webhook registration"
-  value       = "${module.synapse-webhook-api-gateway.api_endpoint}/create"
-}

--- a/deployments/stacks/dpe-k8s/outputs.tf
+++ b/deployments/stacks/dpe-k8s/outputs.tf
@@ -50,3 +50,8 @@ output "smtp_password" {
   sensitive = true
   value     = length(module.sage-aws-ses) > 0 ? module.sage-aws-ses[0].smtp_password : ""
 }
+
+output "synapse_webhook_url" {
+  description = "The URL to use for Synapse webhook registration"
+  value       = module.synapse-sqs-test.api_gateway_url
+}

--- a/modules/aws-api-gateway/README.md
+++ b/modules/aws-api-gateway/README.md
@@ -1,0 +1,43 @@
+# AWS API Gateway Module
+
+This module creates an API Gateway with a default stage that can be used for various integrations.
+
+## Usage
+
+```hcl
+module "api_gateway" {
+  source      = "path/to/modules/aws-api-gateway"
+  environment = "dev"
+  name        = "events-gateway"
+  
+  tags = {
+    Environment = "dev"
+    Application = "api-gateway"
+    ManagedBy   = "terraform"
+  }
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.14 |
+| aws | >= 3.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| environment | The environment name (e.g., dev, staging, prod) | `string` | n/a | yes |
+| name | The name prefix for resources created by this module | `string` | n/a | yes |
+| tags | A map of tags to assign to the API Gateway | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| api_id | The ID of the API Gateway |
+| api_endpoint | The HTTP endpoint of the API Gateway |
+| api_arn | The ARN of the API Gateway |
+| stage_id | The ID of the API Gateway default stage | 

--- a/modules/aws-api-gateway/README.md
+++ b/modules/aws-api-gateway/README.md
@@ -20,24 +20,27 @@ module "api_gateway" {
 
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| terraform | >= 0.14 |
-| aws | >= 3.0 |
+* **terraform**: >= 0.14
+* **aws**: >= 3.0
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| environment | The environment name (e.g., dev, staging, prod) | `string` | n/a | yes |
-| name | The name prefix for resources created by this module | `string` | n/a | yes |
-| tags | A map of tags to assign to the API Gateway | `map(string)` | `{}` | no |
+* **environment**: The environment name (e.g., dev, staging, prod)
+  * Type: `string`
+  * Default: n/a
+  * Required: yes
+* **name**: The name prefix for resources created by this module
+  * Type: `string`
+  * Default: n/a
+  * Required: yes
+* **tags**: A map of tags to assign to the API Gateway
+  * Type: `map(string)`
+  * Default: `{}`
+  * Required: no
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| api_id | The ID of the API Gateway |
-| api_endpoint | The HTTP endpoint of the API Gateway |
-| api_arn | The ARN of the API Gateway |
-| stage_id | The ID of the API Gateway default stage | 
+* **api_id**: The ID of the API Gateway
+* **api_endpoint**: The HTTP endpoint of the API Gateway
+* **api_arn**: The ARN of the API Gateway
+* **stage_id**: The ID of the API Gateway default stage

--- a/modules/aws-api-gateway/README.md
+++ b/modules/aws-api-gateway/README.md
@@ -14,6 +14,7 @@ module "api_gateway" {
     Environment = "dev"
     Application = "api-gateway"
     ManagedBy   = "terraform"
+    CostCenter  = "No Program / 000000"
   }
 }
 ```

--- a/modules/aws-api-gateway/main.tf
+++ b/modules/aws-api-gateway/main.tf
@@ -1,0 +1,11 @@
+resource "aws_apigatewayv2_api" "api_gateway" {
+  name          = "${var.environment}-${var.name}-api"
+  protocol_type = "HTTP"
+  description   = "API Gateway for various integrations"
+}
+
+resource "aws_apigatewayv2_stage" "api_gateway_stage" {
+  api_id = aws_apigatewayv2_api.api_gateway.id
+  name   = "$default"
+  auto_deploy = true
+} 

--- a/modules/aws-api-gateway/main.tf
+++ b/modules/aws-api-gateway/main.tf
@@ -2,10 +2,12 @@ resource "aws_apigatewayv2_api" "api_gateway" {
   name          = "${var.environment}-${var.name}-api"
   protocol_type = "HTTP"
   description   = "API Gateway for various integrations"
+  tags          = var.tags
 }
 
 resource "aws_apigatewayv2_stage" "api_gateway_stage" {
   api_id = aws_apigatewayv2_api.api_gateway.id
   name   = "$default"
   auto_deploy = true
+  tags        = var.tags
 } 

--- a/modules/aws-api-gateway/outputs.tf
+++ b/modules/aws-api-gateway/outputs.tf
@@ -1,0 +1,19 @@
+output "api_id" {
+  description = "The ID of the API Gateway"
+  value       = aws_apigatewayv2_api.api_gateway.id
+}
+
+output "api_endpoint" {
+  description = "The HTTP endpoint of the API Gateway"
+  value       = aws_apigatewayv2_api.api_gateway.api_endpoint
+}
+
+output "api_arn" {
+  description = "The ARN of the API Gateway"
+  value       = aws_apigatewayv2_api.api_gateway.arn
+}
+
+output "stage_id" {
+  description = "The ID of the API Gateway default stage"
+  value       = aws_apigatewayv2_stage.api_gateway_stage.id
+} 

--- a/modules/aws-api-gateway/variables.tf
+++ b/modules/aws-api-gateway/variables.tf
@@ -1,0 +1,15 @@
+variable "environment" {
+  description = "The environment name (e.g., dev, staging, prod)"
+  type        = string
+}
+
+variable "name" {
+  description = "The name prefix for resources created by this module"
+  type        = string
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the API Gateway"
+  type        = map(string)
+  default     = {}
+} 

--- a/modules/aws-api-gateway/variables.tf
+++ b/modules/aws-api-gateway/variables.tf
@@ -9,7 +9,9 @@ variable "name" {
 }
 
 variable "tags" {
-  description = "A map of tags to assign to the API Gateway"
+  description = "Tags to apply to the API Gateway"
   type        = map(string)
-  default     = {}
-} 
+  default = {
+    "CostCenter" = "No Program / 000000"
+  }
+}

--- a/modules/aws-api-gateway/versions.tf
+++ b/modules/aws-api-gateway/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.0"
+    }
+  }
+} 

--- a/modules/aws-sqs/README.md
+++ b/modules/aws-sqs/README.md
@@ -1,0 +1,74 @@
+# AWS SQS Module
+
+This Terraform module creates:
+1. An AWS SQS queue using ACK (AWS Controllers for Kubernetes)
+2. A webhook testing SQS queue directly in AWS
+3. An API Gateway endpoint for testing webhooks that forwards events to the test SQS queue
+
+## Features
+
+- Creates SQS queues using both Kubernetes (ACK) and direct AWS resources
+- Configurable queue attributes like visibility timeout, message retention period, etc.
+- API Gateway integration for webhook testing
+
+## Usage
+
+```hcl
+module "sqs" {
+  source = "modules/aws-sqs"
+
+  environment            = "dev"
+  name                   = "application"
+  queue_name             = "my-queue"
+  namespace              = "default"
+  aws_region             = "us-east-1"
+  aws_account_id         = "123456789012"
+  ack_controller_role_arn = "arn:aws:iam::123456789012:role/ack-sqs-controller"
+  
+  # Optional queue configuration
+  visibility_timeout      = "30"
+  message_retention_period = "345600"
+  delay_seconds           = "0"
+  maximum_message_size    = "262144"
+  
+  tags = {
+    Environment = "dev"
+    Application = "my-app"
+  }
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.0.0 |
+| aws | ~> 5.0 |
+| helm | ~> 2.0 |
+| kubernetes | ~> 2.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| environment | The environment name (e.g., dev, staging, prod) | `string` | n/a | yes |
+| queue_name | The name of the SQS queue | `string` | n/a | yes |
+| namespace | The Kubernetes namespace to deploy to | `string` | `"default"` | no |
+| aws_region | The AWS region to deploy to | `string` | `"us-east-1"` | no |
+| aws_account_id | The AWS account ID | `string` | n/a | yes |
+| ack_controller_role_arn | The ARN of the IAM role for the ACK controller | `string` | n/a | yes |
+| visibility_timeout | The visibility timeout for the queue in seconds | `string` | `"30"` | no |
+| message_retention_period | The message retention period in seconds | `string` | `"345600"` | no |
+| delay_seconds | The delay in seconds before a message becomes available for processing | `string` | `"0"` | no |
+| maximum_message_size | The maximum message size in bytes | `string` | `"262144"` | no |
+| tags | A map of tags to assign to the queue | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| queue_name | The name of the SQS queue |
+| queue_url | The URL of the SQS queue |
+| sqs_queue_url | The URL of the webhook test SQS queue |
+| sqs_queue_arn | The ARN of the webhook test SQS queue |
+| api_gateway_url | The URL of the API Gateway endpoint | 

--- a/modules/aws-sqs/README.md
+++ b/modules/aws-sqs/README.md
@@ -17,6 +17,7 @@ module "api_gateway" {
     Environment = "dev"
     Application = "api-gateway"
     ManagedBy   = "terraform"
+    CostCenter  = "No Program / 000000"
   }
 }
 
@@ -63,6 +64,11 @@ module "standalone_queue" {
   }
 }
 ```
+
+### Configuring an automated Message Consumer
+
+For the proof of concept, we created an Airflow [DAG](https://github.com/Sage-Bionetworks-Workflows/orca-recipes/blob/main/dags/synapse-webhook-poc-dag.py) that automatically polled an SQS queue and processed the messages before sending a message to the intended Synapse users. In order to enable this use case,
+we needed to create an IAM user with access to the SQS queue in the account where the queue was deployed and an AWS Secret connection string containing the credentials for the IAM user in the account where Airflow is deployed.
 
 ## Multiple queues integrated with a single API Gateway
 

--- a/modules/aws-sqs/README.md
+++ b/modules/aws-sqs/README.md
@@ -30,6 +30,7 @@ module "events_queue" {
   cluster_oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/..." 
   
   # API Gateway integration
+  enable_api_gateway_integration = true
   api_gateway_id = module.api_gateway.api_id
   route_path = "/events"
   
@@ -52,7 +53,8 @@ module "standalone_queue" {
   aws_region = "us-east-1"
   cluster_oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/..."
   
-  # Do not provide api_gateway_id to skip integration
+  # Do not enable API Gateway integration
+  enable_api_gateway_integration = false
   
   tags = {
     Environment = "dev"
@@ -77,52 +79,92 @@ module "notifications_queue" {
   source      = "path/to/modules/aws-sqs"
   environment = "dev"
   name        = "notifications-queue"
+  enable_api_gateway_integration = true
   api_gateway_id = module.api_gateway.api_id
   route_path = "/notifications"
-  # ... other required variables
+  aws_account_id = "123456789012"
+  aws_region = "us-east-1"
+  cluster_oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/..."
 }
 
 module "alerts_queue" {
   source      = "path/to/modules/aws-sqs"
   environment = "dev"
   name        = "alerts-queue"
+  enable_api_gateway_integration = true
   api_gateway_id = module.api_gateway.api_id
   route_path = "/alerts"
-  # ... other required variables
+  aws_account_id = "123456789012"
+  aws_region = "us-east-1"
+  cluster_oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/..."
 }
 ```
 
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| terraform | >= 0.14 |
-| aws | >= 3.0 |
+* **terraform**: >= 0.14
+* **aws**: >= 3.0
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| environment | The environment name (e.g., dev, staging, prod) | `string` | n/a | yes |
-| name | The name prefix for resources created by this module | `string` | n/a | yes |
-| aws_region | The AWS region to deploy to | `string` | `"us-east-1"` | no |
-| aws_account_id | The AWS account ID | `string` | n/a | yes |
-| cluster_oidc_provider_arn | The ARN of the OIDC provider for the EKS cluster | `string` | n/a | yes |
-| visibility_timeout | The visibility timeout for the queue in seconds | `number` | `30` | no |
-| message_retention_period | The message retention period in seconds | `number` | `345600` | no |
-| delay_seconds | The delay in seconds before a message becomes available for processing | `number` | `0` | no |
-| maximum_message_size | The maximum message size in bytes | `number` | `262144` | no |
-| tags | A map of tags to assign to the queue | `map(string)` | `{}` | no |
-| api_gateway_id | The ID of the API Gateway to integrate with. If null, no API Gateway integration will be created | `string` | `null` | no |
-| route_path | The path for the API Gateway route (e.g., /events, /messages) | `string` | `/events` | no |
+* **environment**: The environment name (e.g., dev, staging, prod)
+  * Type: `string`
+  * Default: n/a
+  * Required: yes
+* **name**: The name prefix for resources created by this module
+  * Type: `string`
+  * Default: n/a
+  * Required: yes
+* **aws_region**: The AWS region to deploy to
+  * Type: `string`
+  * Default: `"us-east-1"`
+  * Required: no
+* **aws_account_id**: The AWS account ID
+  * Type: `string`
+  * Default: n/a
+  * Required: yes
+* **cluster_oidc_provider_arn**: The ARN of the OIDC provider for the EKS cluster
+  * Type: `string`
+  * Default: n/a
+  * Required: yes
+* **visibility_timeout**: The visibility timeout for the queue in seconds
+  * Type: `number`
+  * Default: `30`
+  * Required: no
+* **message_retention_period**: The message retention period in seconds
+  * Type: `number`
+  * Default: `345600`
+  * Required: no
+* **delay_seconds**: The delay in seconds before a message becomes available for processing
+  * Type: `number`
+  * Default: `0`
+  * Required: no
+* **maximum_message_size**: The maximum message size in bytes
+  * Type: `number`
+  * Default: `262144`
+  * Required: no
+* **tags**: A map of tags to assign to the queue
+  * Type: `map(string)`
+  * Default: `{}`
+  * Required: no
+* **enable_api_gateway_integration**: Whether to enable the API Gateway integration
+  * Type: `bool`
+  * Default: `false`
+  * Required: no
+* **api_gateway_id**: The ID of the API Gateway to integrate with. Required if enable_api_gateway_integration is true.
+  * Type: `string`
+  * Default: `""`
+  * Required: no
+* **route_path**: The path for the API Gateway route (e.g., /events, /messages)
+  * Type: `string`
+  * Default: `/events`
+  * Required: no
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| queue_name | The name of the SQS queue |
-| queue_url | The URL of the SQS queue |
-| queue_arn | The ARN of the SQS queue |
-| api_integration_id | The ID of the API Gateway integration |
-| api_route_key | The route key for the API Gateway route |
-| access_role_arn | ARN of the role to access the SQS queue |
+* **queue_name**: The name of the SQS queue
+* **queue_url**: The URL of the SQS queue
+* **queue_arn**: The ARN of the SQS queue
+* **api_integration_id**: The ID of the API Gateway integration
+* **api_route_key**: The route key for the API Gateway route
+* **access_role_arn**: ARN of the role to access the SQS queue

--- a/modules/aws-sqs/README.md
+++ b/modules/aws-sqs/README.md
@@ -2,14 +2,14 @@
 
 This Terraform module creates:
 1. An AWS SQS queue using ACK (AWS Controllers for Kubernetes)
-2. A webhook testing SQS queue directly in AWS
-3. An API Gateway endpoint for testing webhooks that forwards events to the test SQS queue
+2. A direct AWS SQS queue for API Gateway integration
+3. An API Gateway endpoint that forwards events to the SQS queue
 
 ## Features
 
 - Creates SQS queues using both Kubernetes (ACK) and direct AWS resources
 - Configurable queue attributes like visibility timeout, message retention period, etc.
-- API Gateway integration for webhook testing
+- API Gateway integration for event processing
 
 ## Usage
 
@@ -26,10 +26,10 @@ module "sqs" {
   ack_controller_role_arn = "arn:aws:iam::123456789012:role/ack-sqs-controller"
   
   # Optional queue configuration
-  visibility_timeout      = "30"
-  message_retention_period = "345600"
-  delay_seconds           = "0"
-  maximum_message_size    = "262144"
+  visibility_timeout      = 30
+  message_retention_period = 345600
+  delay_seconds           = 0
+  maximum_message_size    = 262144
   
   tags = {
     Environment = "dev"
@@ -52,15 +52,16 @@ module "sqs" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | environment | The environment name (e.g., dev, staging, prod) | `string` | n/a | yes |
+| name | The name prefix for resources created by this module | `string` | n/a | yes |
 | queue_name | The name of the SQS queue | `string` | n/a | yes |
 | namespace | The Kubernetes namespace to deploy to | `string` | `"default"` | no |
 | aws_region | The AWS region to deploy to | `string` | `"us-east-1"` | no |
 | aws_account_id | The AWS account ID | `string` | n/a | yes |
 | ack_controller_role_arn | The ARN of the IAM role for the ACK controller | `string` | n/a | yes |
-| visibility_timeout | The visibility timeout for the queue in seconds | `string` | `"30"` | no |
-| message_retention_period | The message retention period in seconds | `string` | `"345600"` | no |
-| delay_seconds | The delay in seconds before a message becomes available for processing | `string` | `"0"` | no |
-| maximum_message_size | The maximum message size in bytes | `string` | `"262144"` | no |
+| visibility_timeout | The visibility timeout for the queue in seconds | `number` | `30` | no |
+| message_retention_period | The message retention period in seconds | `number` | `345600` | no |
+| delay_seconds | The delay in seconds before a message becomes available for processing | `number` | `0` | no |
+| maximum_message_size | The maximum message size in bytes | `number` | `262144` | no |
 | tags | A map of tags to assign to the queue | `map(string)` | `{}` | no |
 
 ## Outputs
@@ -69,6 +70,6 @@ module "sqs" {
 |------|-------------|
 | queue_name | The name of the SQS queue |
 | queue_url | The URL of the SQS queue |
-| sqs_queue_url | The URL of the webhook test SQS queue |
-| sqs_queue_arn | The ARN of the webhook test SQS queue |
-| api_gateway_url | The URL of the API Gateway endpoint | 
+| api_queue_url | The URL of the API SQS queue |
+| api_queue_arn | The ARN of the API SQS queue |
+| api_gateway_url | The URL of the API Gateway endpoint |

--- a/modules/aws-sqs/main.tf
+++ b/modules/aws-sqs/main.tf
@@ -83,36 +83,36 @@ resource "aws_apigatewayv2_integration" "sqs_integration" {
   request_parameters = {
     "QueueUrl" = aws_sqs_queue.queue.url
     "MessageBody" = "$request.body"
-    "MessageAttributes" = jsonencode({
-      "WebhookMessageType" = {
-        "DataType" = "String"
-        "StringValue" = "$request.header.X-Syn-Webhook-Message-Type"
-      }
-      "WebhookId" = {
-        "DataType" = "String"
-        "StringValue" = "$request.header.X-Syn-Webhook-Id"
-      }
-      "WebhookMessageId" = {
-        "DataType" = "String"
-        "StringValue" = "$request.header.X-Syn-Webhook-Message-Id"
-      }
-      "WebhookOwnerId" = {
-        "DataType" = "String"
-        "StringValue" = "$request.header.X-Syn-Webhook-Owner-Id"
-      }
-      "ContentType" = {
-        "DataType" = "String"
-        "StringValue" = "$request.header.Content-Type"
-      }
-      "UserAgent" = {
-        "DataType" = "String"
-        "StringValue" = "$request.header.User-Agent"
-      }
-      "Authorization" = {
-        "DataType" = "String"
-        "StringValue" = "$request.header.Authorization"
-      }
-    })
+    # "MessageAttributes" = jsonencode({
+    #   "WebhookMessageType" = {
+    #     "DataType" = "String"
+    #     "StringValue" = "$request.header.X-Syn-Webhook-Message-Type"
+    #   }
+    #   "WebhookId" = {
+    #     "DataType" = "String"
+    #     "StringValue" = "$request.header.X-Syn-Webhook-Id"
+    #   }
+    #   "WebhookMessageId" = {
+    #     "DataType" = "String"
+    #     "StringValue" = "$request.header.X-Syn-Webhook-Message-Id"
+    #   }
+    #   "WebhookOwnerId" = {
+    #     "DataType" = "String"
+    #     "StringValue" = "$request.header.X-Syn-Webhook-Owner-Id"
+    #   }
+    #   "ContentType" = {
+    #     "DataType" = "String"
+    #     "StringValue" = "$request.header.Content-Type"
+    #   }
+    #   "UserAgent" = {
+    #     "DataType" = "String"
+    #     "StringValue" = "$request.header.User-Agent"
+    #   }
+    #   "Authorization" = {
+    #     "DataType" = "String"
+    #     "StringValue" = "$request.header.Authorization"
+    #   }
+    # })
   }
 }
 

--- a/modules/aws-sqs/main.tf
+++ b/modules/aws-sqs/main.tf
@@ -83,36 +83,8 @@ resource "aws_apigatewayv2_integration" "sqs_integration" {
   request_parameters = {
     "QueueUrl" = aws_sqs_queue.queue.url
     "MessageBody" = "$request.body"
-    # "MessageAttributes" = jsonencode({
-    #   "WebhookMessageType" = {
-    #     "DataType" = "String"
-    #     "StringValue" = "$request.header.X-Syn-Webhook-Message-Type"
-    #   }
-    #   "WebhookId" = {
-    #     "DataType" = "String"
-    #     "StringValue" = "$request.header.X-Syn-Webhook-Id"
-    #   }
-    #   "WebhookMessageId" = {
-    #     "DataType" = "String"
-    #     "StringValue" = "$request.header.X-Syn-Webhook-Message-Id"
-    #   }
-    #   "WebhookOwnerId" = {
-    #     "DataType" = "String"
-    #     "StringValue" = "$request.header.X-Syn-Webhook-Owner-Id"
-    #   }
-    #   "ContentType" = {
-    #     "DataType" = "String"
-    #     "StringValue" = "$request.header.Content-Type"
-    #   }
-    #   "UserAgent" = {
-    #     "DataType" = "String"
-    #     "StringValue" = "$request.header.User-Agent"
-    #   }
-    #   "Authorization" = {
-    #     "DataType" = "String"
-    #     "StringValue" = "$request.header.Authorization"
-    #   }
-    # })
+    "MessageAttributes.content-type.DataType" = "String" 
+    "MessageAttributes.content-type.StringValue" = "$request.header.content-type"
   }
 }
 

--- a/modules/aws-sqs/main.tf
+++ b/modules/aws-sqs/main.tf
@@ -92,7 +92,23 @@ resource "aws_apigatewayv2_integration" "sqs_integration" {
         "DataType" = "String"
         "StringValue" = "$request.header.X-Syn-Webhook-Id"
       }
-      "AuthorizationHeader" = {
+      "WebhookMessageId" = {
+        "DataType" = "String"
+        "StringValue" = "$request.header.X-Syn-Webhook-Message-Id"
+      }
+      "WebhookOwnerId" = {
+        "DataType" = "String"
+        "StringValue" = "$request.header.X-Syn-Webhook-Owner-Id"
+      }
+      "ContentType" = {
+        "DataType" = "String"
+        "StringValue" = "$request.header.Content-Type"
+      }
+      "UserAgent" = {
+        "DataType" = "String"
+        "StringValue" = "$request.header.User-Agent"
+      }
+      "Authorization" = {
         "DataType" = "String"
         "StringValue" = "$request.header.Authorization"
       }

--- a/modules/aws-sqs/main.tf
+++ b/modules/aws-sqs/main.tf
@@ -30,7 +30,7 @@ resource "aws_sqs_queue_policy" "queue_policy" {
 
 # API Gateway to SQS Integration
 resource "aws_iam_role" "api_gateway_sqs_role" {
-  count = var.api_gateway_id != null ? 1 : 0
+  count = var.enable_api_gateway_integration ? 1 : 0
   name = "${var.environment}-${var.name}-api-gateway-sqs-role"
 
   assume_role_policy = jsonencode({
@@ -48,7 +48,7 @@ resource "aws_iam_role" "api_gateway_sqs_role" {
 }
 
 resource "aws_iam_role_policy" "api_gateway_sqs_policy" {
-  count = var.api_gateway_id != null ? 1 : 0
+  count = var.enable_api_gateway_integration ? 1 : 0
   name = "${var.environment}-${var.name}-api-gateway-sqs-policy"
   role = aws_iam_role.api_gateway_sqs_role[0].id
 
@@ -65,7 +65,7 @@ resource "aws_iam_role_policy" "api_gateway_sqs_policy" {
 }
 
 resource "aws_apigatewayv2_integration" "sqs_integration" {
-  count = var.api_gateway_id != null ? 1 : 0
+  count = var.enable_api_gateway_integration ? 1 : 0
   api_id           = var.api_gateway_id
   integration_type = "AWS_PROXY"
   integration_subtype = "SQS-SendMessage"
@@ -85,7 +85,7 @@ resource "aws_apigatewayv2_integration" "sqs_integration" {
 }
 
 resource "aws_apigatewayv2_route" "events_route" {
-  count = var.api_gateway_id != null ? 1 : 0
+  count = var.enable_api_gateway_integration ? 1 : 0
   api_id    = var.api_gateway_id
   route_key = "POST ${var.route_path}"
   target    = "integrations/${aws_apigatewayv2_integration.sqs_integration[0].id}"

--- a/modules/aws-sqs/main.tf
+++ b/modules/aws-sqs/main.tf
@@ -84,13 +84,13 @@ resource "aws_apigatewayv2_integration" "sqs_integration" {
     "QueueUrl" = aws_sqs_queue.queue.url
     "MessageBody" = "$request.body"
     "MessageAttributes" = jsonencode({
-      "MessageType" = {
+      "WebhookMessageType" = {
         "DataType" = "String"
-        "StringValue" = "$request.header.X-Message-Type"
+        "StringValue" = "$request.header.X-Syn-Webhook-Message-Type"
       }
-      "MessageId" = {
+      "WebhookId" = {
         "DataType" = "String"
-        "StringValue" = "$request.header.X-Message-Id"
+        "StringValue" = "$request.header.X-Syn-Webhook-Id"
       }
       "AuthorizationHeader" = {
         "DataType" = "String"

--- a/modules/aws-sqs/main.tf
+++ b/modules/aws-sqs/main.tf
@@ -84,9 +84,9 @@ resource "aws_apigatewayv2_integration" "sqs_integration" {
     "QueueUrl" = aws_sqs_queue.queue.url
     "MessageBody" = "$request.body"
     "MessageAttributes" = jsonencode({
-      "ContentType" = {
-        "DataType" = "String"
-        "StringValue" = "$request.header.Content-Type"
+      "ApiSource": {
+        "DataType": "String",
+        "StringValue": "ApiGateway"
       }
     })
   }

--- a/modules/aws-sqs/main.tf
+++ b/modules/aws-sqs/main.tf
@@ -28,7 +28,6 @@ resource "aws_sqs_queue_policy" "queue_policy" {
   })
 }
 
-# API Gateway to SQS Integration
 resource "aws_iam_role" "api_gateway_sqs_role" {
   count = var.enable_api_gateway_integration ? 1 : 0
   name = "${var.environment}-${var.name}-api-gateway-sqs-role"

--- a/modules/aws-sqs/main.tf
+++ b/modules/aws-sqs/main.tf
@@ -83,8 +83,12 @@ resource "aws_apigatewayv2_integration" "sqs_integration" {
   request_parameters = {
     "QueueUrl" = aws_sqs_queue.queue.url
     "MessageBody" = "$request.body"
-    "MessageAttributes.content-type.DataType" = "String" 
-    "MessageAttributes.content-type.StringValue" = "$request.header.content-type"
+    "MessageAttributes" = jsonencode({
+      "ContentType" = {
+        "DataType" = "String"
+        "StringValue" = "$request.header.Content-Type"
+      }
+    })
   }
 }
 

--- a/modules/aws-sqs/main.tf
+++ b/modules/aws-sqs/main.tf
@@ -1,0 +1,143 @@
+resource "helm_release" "ack_sqs_controller" {
+  name       = "ack-sqs-controller"
+  repository = "oci://public.ecr.aws/aws-controllers-k8s"
+  chart      = "sqs-chart"
+  version    = "1.0.6"
+  namespace  = var.namespace
+
+  set {
+    name  = "aws.region"
+    value = var.aws_region
+  }
+
+  set {
+    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+    value = var.ack_controller_role_arn
+  }
+}
+
+resource "kubernetes_manifest" "sqs_queue" {
+  depends_on = [helm_release.ack_sqs_controller]
+
+  manifest = {
+    apiVersion = "sqs.services.k8s.aws/v1alpha1"
+    kind       = "Queue"
+    metadata = {
+      name      = var.queue_name
+      namespace = var.namespace
+    }
+    spec = {
+      name = var.queue_name
+      queueAttributes = {
+        VisibilityTimeout = var.visibility_timeout
+        MessageRetentionPeriod = var.message_retention_period
+        DelaySeconds = var.delay_seconds
+        MaximumMessageSize = var.maximum_message_size
+      }
+      tags = var.tags
+    }
+  }
+}
+
+resource "aws_sqs_queue" "webhook_test_queue" {
+  name                      = "${var.environment}-${var.name}-webhook-test"
+  visibility_timeout        = 30
+  message_retention_seconds = 345600  # 4 days
+  tags = {
+    Environment = var.environment
+    Name        = var.name
+  }
+}
+
+resource "aws_sqs_queue_policy" "webhook_test_queue_policy" {
+  queue_url = aws_sqs_queue.webhook_test_queue.id
+  policy    = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = ["sqs:SendMessage"]
+        Resource  = aws_sqs_queue.webhook_test_queue.arn
+      }
+    ]
+  })
+}
+
+resource "aws_apigatewayv2_api" "webhook_test_api" {
+  name          = "${var.environment}-${var.name}-webhook-test-api"
+  protocol_type = "HTTP"
+  description   = "API for testing webhooks, forwards events to a testing SQS queue"
+}
+
+resource "aws_apigatewayv2_stage" "webhook_test_api_stage" {
+  api_id = aws_apigatewayv2_api.webhook_test_api.id
+  name   = "$default"
+  auto_deploy = true
+}
+
+resource "aws_iam_role" "api_gateway_sqs_role" {
+  name = "${var.environment}-${var.name}-api-gateway-sqs-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "apigateway.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "api_gateway_sqs_policy" {
+  name = "${var.environment}-${var.name}-api-gateway-sqs-policy"
+  role = aws_iam_role.api_gateway_sqs_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = ["sqs:SendMessage"]
+        Resource = aws_sqs_queue.webhook_test_queue.arn
+      }
+    ]
+  })
+}
+
+resource "aws_apigatewayv2_integration" "webhook_test_sqs_integration" {
+  api_id           = aws_apigatewayv2_api.webhook_test_api.id
+  integration_type = "AWS_PROXY"
+  integration_subtype = "SQS-SendMessage"
+  payload_format_version = "1.0"
+  credentials_arn = aws_iam_role.api_gateway_sqs_role.arn
+
+  request_parameters = {
+    "QueueUrl" = aws_sqs_queue.webhook_test_queue.url
+    "MessageBody" = "$request.body"
+    "MessageAttributes" = jsonencode({
+      "WebhookMessageType" = {
+        "DataType" = "String"
+        "StringValue" = "$request.header.X-Syn-Webhook-Message-Type"
+      }
+      "WebhookId" = {
+        "DataType" = "String"
+        "StringValue" = "$request.header.X-Syn-Webhook-Id"
+      }
+      "AuthorizationHeader" = {
+        "DataType" = "String"
+        "StringValue" = "$request.header.Authorization"
+      }
+    })
+  }
+}
+
+resource "aws_apigatewayv2_route" "webhook_test_route" {
+  api_id    = aws_apigatewayv2_api.webhook_test_api.id
+  route_key = "POST /events"
+  target    = "integrations/${aws_apigatewayv2_integration.webhook_test_sqs_integration.id}"
+} 

--- a/modules/aws-sqs/outputs.tf
+++ b/modules/aws-sqs/outputs.tf
@@ -13,9 +13,14 @@ output "queue_arn" {
   value       = aws_sqs_queue.queue.arn
 }
 
-output "api_gateway_url" {
-  description = "The URL of the API Gateway endpoint"
-  value       = "${aws_apigatewayv2_api.api_gateway.api_endpoint}/events"
+output "api_integration_id" {
+  description = "The ID of the API Gateway integration"
+  value       = var.api_gateway_id != null ? aws_apigatewayv2_integration.sqs_integration[0].id : null
+}
+
+output "api_route_key" {
+  description = "The route key for the API Gateway route"
+  value       = var.api_gateway_id != null ? aws_apigatewayv2_route.events_route[0].route_key : null
 }
 
 output "access_role_arn" {

--- a/modules/aws-sqs/outputs.tf
+++ b/modules/aws-sqs/outputs.tf
@@ -15,7 +15,7 @@ output "queue_arn" {
 
 output "api_gateway_url" {
   description = "The URL of the API Gateway endpoint"
-  value       = "${aws_apigatewayv2_api.api_gateway.api_endpoint}/${aws_apigatewayv2_stage.api_gateway_stage.name}"
+  value       = "${aws_apigatewayv2_api.api_gateway.api_endpoint}/events"
 }
 
 output "access_role_arn" {

--- a/modules/aws-sqs/outputs.tf
+++ b/modules/aws-sqs/outputs.tf
@@ -8,17 +8,17 @@ output "queue_url" {
   value       = "https://sqs.${var.aws_region}.amazonaws.com/${var.aws_account_id}/${var.queue_name}"
 }
 
-output "sqs_queue_url" {
-  description = "The URL of the SQS queue"
-  value       = aws_sqs_queue.webhook_test_queue.url
+output "api_queue_url" {
+  description = "The URL of the API SQS queue"
+  value       = aws_sqs_queue.api_queue.url
 }
 
-output "sqs_queue_arn" {
-  description = "The ARN of the SQS queue"
-  value       = aws_sqs_queue.webhook_test_queue.arn
+output "api_queue_arn" {
+  description = "The ARN of the API SQS queue"
+  value       = aws_sqs_queue.api_queue.arn
 }
 
 output "api_gateway_url" {
   description = "The URL of the API Gateway endpoint"
-  value       = "${aws_apigatewayv2_api.webhook_test_api.api_endpoint}/${aws_apigatewayv2_stage.webhook_test_api_stage.name}"
+  value       = "${aws_apigatewayv2_api.api_gateway.api_endpoint}/${aws_apigatewayv2_stage.api_gateway_stage.name}"
 } 

--- a/modules/aws-sqs/outputs.tf
+++ b/modules/aws-sqs/outputs.tf
@@ -1,0 +1,24 @@
+output "queue_name" {
+  description = "The name of the SQS queue"
+  value       = var.queue_name
+}
+
+output "queue_url" {
+  description = "The URL of the SQS queue"
+  value       = "https://sqs.${var.aws_region}.amazonaws.com/${var.aws_account_id}/${var.queue_name}"
+}
+
+output "sqs_queue_url" {
+  description = "The URL of the SQS queue"
+  value       = aws_sqs_queue.webhook_test_queue.url
+}
+
+output "sqs_queue_arn" {
+  description = "The ARN of the SQS queue"
+  value       = aws_sqs_queue.webhook_test_queue.arn
+}
+
+output "api_gateway_url" {
+  description = "The URL of the API Gateway endpoint"
+  value       = "${aws_apigatewayv2_api.webhook_test_api.api_endpoint}/${aws_apigatewayv2_stage.webhook_test_api_stage.name}"
+} 

--- a/modules/aws-sqs/outputs.tf
+++ b/modules/aws-sqs/outputs.tf
@@ -1,24 +1,24 @@
 output "queue_name" {
   description = "The name of the SQS queue"
-  value       = var.queue_name
+  value       = aws_sqs_queue.queue.name
 }
 
 output "queue_url" {
   description = "The URL of the SQS queue"
-  value       = "https://sqs.${var.aws_region}.amazonaws.com/${var.aws_account_id}/${var.queue_name}"
+  value       = aws_sqs_queue.queue.url
 }
 
-output "api_queue_url" {
-  description = "The URL of the API SQS queue"
-  value       = aws_sqs_queue.api_queue.url
-}
-
-output "api_queue_arn" {
-  description = "The ARN of the API SQS queue"
-  value       = aws_sqs_queue.api_queue.arn
+output "queue_arn" {
+  description = "The ARN of the SQS queue"
+  value       = aws_sqs_queue.queue.arn
 }
 
 output "api_gateway_url" {
   description = "The URL of the API Gateway endpoint"
   value       = "${aws_apigatewayv2_api.api_gateway.api_endpoint}/${aws_apigatewayv2_stage.api_gateway_stage.name}"
+}
+
+output "access_role_arn" {
+  description = "ARN of the role to access the SQS queue"
+  value       = aws_iam_role.sqs_access_role.arn
 } 

--- a/modules/aws-sqs/outputs.tf
+++ b/modules/aws-sqs/outputs.tf
@@ -15,12 +15,12 @@ output "queue_arn" {
 
 output "api_integration_id" {
   description = "The ID of the API Gateway integration"
-  value       = var.api_gateway_id != null ? aws_apigatewayv2_integration.sqs_integration[0].id : null
+  value       = var.enable_api_gateway_integration ? aws_apigatewayv2_integration.sqs_integration[0].id : null
 }
 
 output "api_route_key" {
   description = "The route key for the API Gateway route"
-  value       = var.api_gateway_id != null ? aws_apigatewayv2_route.events_route[0].route_key : null
+  value       = var.enable_api_gateway_integration ? aws_apigatewayv2_route.events_route[0].route_key : null
 }
 
 output "access_role_arn" {

--- a/modules/aws-sqs/variables.tf
+++ b/modules/aws-sqs/variables.tf
@@ -52,4 +52,17 @@ variable "tags" {
   description = "A map of tags to assign to the queue"
   type        = map(string)
   default     = {}
+}
+
+# API Gateway Integration Variables
+variable "api_gateway_id" {
+  description = "The ID of the API Gateway to integrate with. If null, no API Gateway integration will be created."
+  type        = string
+  default     = null
+}
+
+variable "route_path" {
+  description = "The path for the API Gateway route (e.g., /events, /messages)"
+  type        = string
+  default     = "/events"
 } 

--- a/modules/aws-sqs/variables.tf
+++ b/modules/aws-sqs/variables.tf
@@ -49,9 +49,11 @@ variable "maximum_message_size" {
 }
 
 variable "tags" {
-  description = "A map of tags to assign to the queue"
+  description = "Tags to apply to the SQS queue"
   type        = map(string)
-  default     = {}
+  default = {
+    "CostCenter" = "No Program / 000000"
+  }
 }
 
 variable "enable_api_gateway_integration" {

--- a/modules/aws-sqs/variables.tf
+++ b/modules/aws-sqs/variables.tf
@@ -54,7 +54,6 @@ variable "tags" {
   default     = {}
 }
 
-# API Gateway Integration Variables
 variable "enable_api_gateway_integration" {
   description = "Whether to enable the API Gateway integration"
   type        = bool

--- a/modules/aws-sqs/variables.tf
+++ b/modules/aws-sqs/variables.tf
@@ -8,17 +8,6 @@ variable "name" {
   type        = string
 }
 
-variable "queue_name" {
-  description = "The name of the SQS queue"
-  type        = string
-}
-
-variable "namespace" {
-  description = "The Kubernetes namespace to deploy to"
-  type        = string
-  default     = "default"
-}
-
 variable "aws_region" {
   description = "The AWS region to deploy to"
   type        = string
@@ -30,8 +19,8 @@ variable "aws_account_id" {
   type        = string
 }
 
-variable "ack_controller_role_arn" {
-  description = "The ARN of the IAM role for the ACK controller"
+variable "cluster_oidc_provider_arn" {
+  description = "The ARN of the OIDC provider for the EKS cluster"
   type        = string
 }
 

--- a/modules/aws-sqs/variables.tf
+++ b/modules/aws-sqs/variables.tf
@@ -37,26 +37,26 @@ variable "ack_controller_role_arn" {
 
 variable "visibility_timeout" {
   description = "The visibility timeout for the queue in seconds"
-  type        = string
-  default     = "30"
+  type        = number
+  default     = 30
 }
 
 variable "message_retention_period" {
   description = "The message retention period in seconds"
-  type        = string
-  default     = "345600"  # 4 days
+  type        = number
+  default     = 345600  # 4 days
 }
 
 variable "delay_seconds" {
   description = "The delay in seconds before a message becomes available for processing"
-  type        = string
-  default     = "0"
+  type        = number
+  default     = 0
 }
 
 variable "maximum_message_size" {
   description = "The maximum message size in bytes"
-  type        = string
-  default     = "262144"  # 256 KiB
+  type        = number
+  default     = 262144  # 256 KiB
 }
 
 variable "tags" {

--- a/modules/aws-sqs/variables.tf
+++ b/modules/aws-sqs/variables.tf
@@ -55,10 +55,16 @@ variable "tags" {
 }
 
 # API Gateway Integration Variables
+variable "enable_api_gateway_integration" {
+  description = "Whether to enable the API Gateway integration"
+  type        = bool
+  default     = false
+}
+
 variable "api_gateway_id" {
-  description = "The ID of the API Gateway to integrate with. If null, no API Gateway integration will be created."
+  description = "The ID of the API Gateway to integrate with. Required if enable_api_gateway_integration is true."
   type        = string
-  default     = null
+  default     = ""
 }
 
 variable "route_path" {

--- a/modules/aws-sqs/variables.tf
+++ b/modules/aws-sqs/variables.tf
@@ -1,0 +1,66 @@
+variable "environment" {
+  description = "The environment name (e.g., dev, staging, prod)"
+  type        = string
+}
+
+variable "name" {
+  description = "The name prefix for resources created by this module"
+  type        = string
+}
+
+variable "queue_name" {
+  description = "The name of the SQS queue"
+  type        = string
+}
+
+variable "namespace" {
+  description = "The Kubernetes namespace to deploy to"
+  type        = string
+  default     = "default"
+}
+
+variable "aws_region" {
+  description = "The AWS region to deploy to"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "aws_account_id" {
+  description = "The AWS account ID"
+  type        = string
+}
+
+variable "ack_controller_role_arn" {
+  description = "The ARN of the IAM role for the ACK controller"
+  type        = string
+}
+
+variable "visibility_timeout" {
+  description = "The visibility timeout for the queue in seconds"
+  type        = string
+  default     = "30"
+}
+
+variable "message_retention_period" {
+  description = "The message retention period in seconds"
+  type        = string
+  default     = "345600"  # 4 days
+}
+
+variable "delay_seconds" {
+  description = "The delay in seconds before a message becomes available for processing"
+  type        = string
+  default     = "0"
+}
+
+variable "maximum_message_size" {
+  description = "The maximum message size in bytes"
+  type        = string
+  default     = "262144"  # 256 KiB
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the queue"
+  type        = map(string)
+  default     = {}
+} 

--- a/modules/aws-sqs/versions.tf
+++ b/modules/aws-sqs/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+  required_version = ">= 1.0.0"
+} 

--- a/modules/aws-sqs/versions.tf
+++ b/modules/aws-sqs/versions.tf
@@ -4,14 +4,6 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
-    helm = {
-      source  = "hashicorp/helm"
-      version = "~> 2.0"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "~> 2.0"
-    }
   }
   required_version = ">= 1.0.0"
 } 


### PR DESCRIPTION
# **Problem:**

We do not currently have reusable IaC components to spin up SQS queues.

# **Solution:**

Implemented Terraform modules to create an AWS API Gateway and SQS queues that integrate with a specified API Gateway. With both of these components, we can send requests to the API Gateway and route them to appropriate SQS queues which can then be polled by downstream processes. This implementation allows us to have multiple SQS queues per API Gateway by simply assigning one route to each queue. This is just one way we could take a polling approach to receive messages generated by Synapse Webhooks. Another way we might want to look into is a push-based approach with SNS topics that downstream resources subscribe to. 

For the purposes of SYNPY-1587, I created an [Airflow DAG](https://github.com/Sage-Bionetworks-Workflows/orca-recipes/pull/87) that polls the SQS queue, but lighter-weight AWS resources like Lambda functions with SQS triggers or that subscribe to SNS topics (also managed with IaC code) may be preferable for production notification systems.

# **Testing:**

Deployed the infrastructure on the dnt-dev AWS account using Terraform + Spacelift and tested with a [Python script](https://gist.github.com/BWMac/fc406be9e4a2aee39c659465e9c9f3e7).

# **Notes:**

When merged, this PR will not include any API Gateways or SQS queues being deployed to the production account because we do not have immediate need for these resources.
