### PR TITLE
Increase storage size from 8Gi to 30Gi in cluster configuration

### DIFF
--- a/modules/postgres-cloud-native/templates/cluster-values.yaml
+++ b/modules/postgres-cloud-native/templates/cluster-values.yaml
@@ -99,7 +99,7 @@ cluster:
   imagePullSecrets: []
 
   storage:
-    size: 8Gi
+    size: 30Gi
     storageClass: ""
 
   # -- The UID of the postgres user inside the image, defaults to 26


### PR DESCRIPTION
# **Problem:**

- The Postgres DB ran out of storage

# **Solution:**

- Increase to 30Gi

# **Testing:**

- Will be testing out the deployment
