### PR TITLE
[feat]: upgrade K8s cluster to 1.32

### DIFF
--- a/modules/sage-aws-eks/variables.tf
+++ b/modules/sage-aws-eks/variables.tf
@@ -6,7 +6,7 @@ variable "cluster_name" {
 variable "cluster_version" {
   description = "Version of K8 cluster"
   type        = string
-  default     = "1.31"
+  default     = "1.33"
 }
 
 variable "region" {

--- a/modules/sage-aws-eks/variables.tf
+++ b/modules/sage-aws-eks/variables.tf
@@ -6,7 +6,7 @@ variable "cluster_name" {
 variable "cluster_version" {
   description = "Version of K8 cluster"
   type        = string
-  default     = "1.33"
+  default     = "1.32"
 }
 
 variable "region" {


### PR DESCRIPTION
# **Problem:**
The current K8s cluster is reaching the end of life by October this year. See documentation [here](https://kubernetes.io/releases/#release-v1-31). 

# **Solution:**
Update to use K8s version 1.32 for now and 1.33 in the end [here](https://kubernetes.io/releases/#release-v1-33)