### PR TITLE
Revert "[feat]: update version to 1.33"

### DIFF
--- a/modules/sage-aws-eks/variables.tf
+++ b/modules/sage-aws-eks/variables.tf
@@ -6,7 +6,7 @@ variable "cluster_name" {
 variable "cluster_version" {
   description = "Version of K8 cluster"
   type        = string
-  default     = "1.33"
+  default     = "1.32"
 }
 
 variable "region" {


### PR DESCRIPTION
Reverts Sage-Bionetworks-Workflows/eks-stack#69

Due to an error noted by @BryanFauble [here](https://github.com/spotinst/terraform-spotinst-ocean-aws-k8s/issues/59), revert back to Kubernetes version 1.32. 