### PR TITLE
[DPE-1423] Swap ocean-aws-k8s module to support provided commit

### DIFF
--- a/deployments/stacks/dpe-k8s-deployments/main.tf
+++ b/deployments/stacks/dpe-k8s-deployments/main.tf
@@ -2,8 +2,7 @@ locals {
   git_revision = var.git_revision
 }
 module "sage-aws-eks-autoscaler" {
-  source                 = "spacelift.io/sagebionetworks/sage-aws-eks-autoscaler/aws"
-  version                = "0.9.0"
+  source                 = "../../../modules/sage-aws-k8s-node-autoscaler"
   cluster_name           = var.cluster_name
   private_vpc_subnet_ids = var.private_subnet_ids_eks_worker_nodes
   vpc_id                 = var.vpc_id

--- a/modules/sage-aws-k8s-node-autoscaler/main.tf
+++ b/modules/sage-aws-k8s-node-autoscaler/main.tf
@@ -105,8 +105,8 @@ resource "helm_release" "ocean-kubernetes-controller" {
 
 
 module "ocean-aws-k8s" {
-  source  = "spotinst/ocean-aws-k8s/spotinst"
-  version = "1.4.0"
+  source  = "git::https://github.com/spotinst/terraform-spotinst-ocean-aws-k8s.git?ref=7a30a60b4d0af3a7847467ac373511f3da58e40a"
+  # version = "1.4.0"
 
   # Configuration
   cluster_name                     = var.cluster_name

--- a/modules/sage-aws-k8s-node-autoscaler/main.tf
+++ b/modules/sage-aws-k8s-node-autoscaler/main.tf
@@ -105,8 +105,8 @@ resource "helm_release" "ocean-kubernetes-controller" {
 
 
 module "ocean-aws-k8s" {
-  source  = "git::https://github.com/spotinst/terraform-spotinst-ocean-aws-k8s.git?ref=7a30a60b4d0af3a7847467ac373511f3da58e40a"
-  # version = "1.4.0"
+  source  = "spotinst/ocean-aws-k8s/spotinst"
+  version = "1.11.0"
 
   # Configuration
   cluster_name                     = var.cluster_name
@@ -148,3 +148,4 @@ module "ocean-aws-k8s" {
     virtualization_types    = null
   }
 }
+

--- a/modules/sage-aws-k8s-node-autoscaler/versions.tf
+++ b/modules/sage-aws-k8s-node-autoscaler/versions.tf
@@ -9,8 +9,8 @@ terraform {
       version = "~> 2.0"
     }
     spotinst = {
-      source  = "spotinst/spotinst"
-      version = "1.172.0" # Specify the version you wish to use
+      source  = "opentofu/spotinst"
+      version = "1.225.0" # Specify the version you wish to use
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
# **Problem:**

- 1.33 broke the Spotinst terraform module as the filter used is no longer valid for AWS published images

# **Solution:**

- Use the commit hash provided by support

# **Testing:**

- Update source and point the stack to use the local version instead of one from the private module registery
