### PR TITLE
[HOTFIX] Update Snowflake external ID on `prod` RDS snapshots IAM role policy

### DIFF
--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -193,5 +193,5 @@ module "snowflake-spacelift-production" {
   
   # Snowflake authentication
   snowflake_principal_arn = "arn:aws:iam::365909334157:user/m2nb0000-s"
-  snowflake_external_id   = "UO70315_SFCRole=2_QLtciGyxAkOBnGt020rTOOLSjZ8="
+  snowflake_external_id   = "UO70315_SFCRole=2_sMkYAFbXNh67rjuHYzC7VLcToh4="
 }

--- a/modules/snowflake-s3-bucket/README.md
+++ b/modules/snowflake-s3-bucket/README.md
@@ -141,7 +141,7 @@ This will provide you with the `STORAGE_AWS_IAM_USER_ARN` (use for `snowflake_pr
 | source_account_id | AWS account ID that will replicate TO this bucket | `string` | n/a | yes |
 | source_bucket_arn | ARN of the source bucket that will replicate to this bucket | `string` | n/a | yes |
 | snowflake_principal_arn | ARN of the Snowflake principal (user or role) that will assume the role | `string` | n/a | yes |
-| snowflake_external_id | External ID for Snowflake role assumption | `string` | n/a | yes |
+| snowflake_external_id | The externald ID that Snowflake uses to establish a trust relationship with AWS. You must specify the same external ID in the trust policy of the IAM role that you configured for this storage integration. <br> <br>This can be retrieved on Snowflake via the SQL command `DESC STORAGE INTEGRATION <integration_name>`. | `string` | n/a | yes |
 | tags | Additional tags for the S3 bucket | `map(string)` | `{}` | no |
 | public_access | Enable public access to the bucket | `bool` | `false` | no |
 | enable_cors | Enable CORS configuration | `bool` | `false` | no |

--- a/modules/snowflake-s3-bucket/README.md
+++ b/modules/snowflake-s3-bucket/README.md
@@ -140,7 +140,7 @@ This will provide you with the `STORAGE_AWS_IAM_USER_ARN` (use for `snowflake_pr
 | enable_versioning | Enable versioning on the S3 bucket | `bool` | `true` | no |
 | source_account_id | AWS account ID that will replicate TO this bucket | `string` | n/a | yes |
 | source_bucket_arn | ARN of the source bucket that will replicate to this bucket | `string` | n/a | yes |
-| snowflake_principal_arn | ARN of the Snowflake principal (user or role) that will assume the role | `string` | n/a | yes |
+| snowflake_principal_arn | ARN of the Snowflake principal (user) that will assume the IAM role for ingesting RDS snapshots from the S3 bucket. <br> <br>This can be retrieved on Snowflake via the SQL command `DESC STORAGE INTEGRATION <integration_name>` with the property listed as `STORAGE_AWS_IAM_USER_ARN`.| `string` | n/a | yes |
 | snowflake_external_id | The externald ID that Snowflake uses to establish a trust relationship with AWS. You must specify the same external ID in the trust policy of the IAM role that you configured for this storage integration. <br> <br>This can be retrieved on Snowflake via the SQL command `DESC STORAGE INTEGRATION <integration_name>`. | `string` | n/a | yes |
 | tags | Additional tags for the S3 bucket | `map(string)` | `{}` | no |
 | public_access | Enable public access to the bucket | `bool` | `false` | no |


### PR DESCRIPTION
# **Problem:**

The `prod` storage integration on Snowflake is failing to assume its designated IAM role on AWS with this error:

```
snowflake.connector.errors.ProgrammingError: 003167 (42601): Error assuming AWS_ROLE:
User: arn:aws:iam::365909334157:user/m2nb0000-s is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::766808016710:role/snowflake-role-synapse-snowflake-rds-snapshots-prod
```

# **Solution:**

priv. comm. from me to Phil:
> _It looks like the external ID for the PROD storage integration doesn't match up with the one used in the IAM role policy. The external ID gets randomly generated every time you create (or re-create) a storage integration on Snowflake, and I must have re-created the PROD one without updating our terraform scripts with the new ID._

- [x] Update `snowflake_external_id` for `prod` stack
- [x] Updated the description for the snowflake_external_id parameter to clarify its purpose and how to retrieve it.

# **Testing:**

Testing requires a re-run of [this `schemachange` job](https://github.com/Sage-Bionetworks/snowflake/actions/runs/23825217190/job/69446518899) after re-deploying the `prod` stack on Spacelift. Results below:

<img width="1219" height="108" alt="image" src="https://github.com/user-attachments/assets/9b6125b1-e395-48d0-8582-c401251c974e" />

Fixed ✅ 