### PR TITLE
Update snowflake_external_id in main.tf

### DIFF
--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -166,7 +166,7 @@ module "snowflake-spacelift-development" {
   
   # Snowflake authentication
   snowflake_principal_arn = "arn:aws:iam::365909334157:user/m2nb0000-s"
-  snowflake_external_id   = "UO70315_SFCRole=2_0VqqeWxjpuUoM4zVlbsAl5vnp/o="
+  snowflake_external_id   = "UO70315_SFCRole=2_PQyc1mUCluvv6W2lycbjCbYbjjI="
 }
 
 module "snowflake-spacelift-production" {

--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -166,7 +166,7 @@ module "snowflake-spacelift-development" {
   
   # Snowflake authentication
   snowflake_principal_arn = "arn:aws:iam::365909334157:user/m2nb0000-s"
-  snowflake_external_id   = "UO70315_SFCRole=2_PQyc1mUCluvv6W2lycbjCbYbjjI="
+  snowflake_external_id   = "UO70315_SFCRole=2_QYIb43i20hlGZ/yzhC8zoAzsE8E="
 }
 
 module "snowflake-spacelift-production" {
@@ -193,5 +193,5 @@ module "snowflake-spacelift-production" {
   
   # Snowflake authentication
   snowflake_principal_arn = "arn:aws:iam::365909334157:user/m2nb0000-s"
-  snowflake_external_id   = "UO70315_SFCRole=2_fsK3pPAcOO/1WXSpHyHmGSVzYHo="
+  snowflake_external_id   = "UO70315_SFCRole=2_MrT3ubydhclba/9w8Kq1btbWsBc="
 }

--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -193,5 +193,5 @@ module "snowflake-spacelift-production" {
   
   # Snowflake authentication
   snowflake_principal_arn = "arn:aws:iam::365909334157:user/m2nb0000-s"
-  snowflake_external_id   = "UO70315_SFCRole=2_sMkYAFbXNh67rjuHYzC7VLcToh4="
+  snowflake_external_id   = "UO70315_SFCRole=2_fsK3pPAcOO/1WXSpHyHmGSVzYHo="
 }


### PR DESCRIPTION
# **Problem:**

The external ID for the `dev` storage integration was also outdated

# **Solution:**

Update accordingly

# **Testing:**

Attempting to refresh the stage pointing to this storage integration should work:

<img width="1139" height="231" alt="image" src="https://github.com/user-attachments/assets/928da65c-8c3b-40f4-adf3-cb491ebe4c85" />

Looks good ✅ 
