### PR TITLE
Test CeleryKubernetesExecutor for Airflow

### DIFF
--- a/modules/apache-airflow/templates/values.yaml
+++ b/modules/apache-airflow/templates/values.yaml
@@ -267,7 +267,7 @@ rbac:
 # Airflow executor
 # One of: LocalExecutor, LocalKubernetesExecutor, CeleryExecutor, KubernetesExecutor, CeleryKubernetesExecutor
 # Specify executors in a prioritized list to leverage multiple execution environments as needed.
-executor: "CeleryExecutor"
+executor: "CeleryKubernetesExecutor"
 
 # If this is true and using LocalExecutor/KubernetesExecutor/CeleryKubernetesExecutor, the scheduler's
 # service account will have access to communicate with the api-server and launch pods.


### PR DESCRIPTION
# **Problem:**

- The current Airflow deployment uses `CeleryExecutor`, which runs all tasks on Celery workers
- We want to evaluate `CeleryKubernetesExecutor` to enable hybrid task execution, where most tasks run on Celery workers but specific tasks can be dispatched to ephemeral Kubernetes pods

# **Solution:**

- Changed `executor` from `CeleryExecutor` to `CeleryKubernetesExecutor` in `modules/apache-airflow/templates/values.yaml`
- `CeleryKubernetesExecutor` is a hybrid executor that combines Celery and Kubernetes execution environments
- Tasks with the `queue=kubernetes` queue attribute will run as Kubernetes pods; all other tasks continue to run on Celery workers
- `allowPodLaunching: true` is already set in the values template, so the scheduler and workers have the necessary permissions to launch pods

# **Testing:**

- [ ] Validate that Airflow deploys successfully with the new executor
- [ ] Confirm Celery workers start and continue to process standard tasks
- [ ] Confirm tasks routed to the Kubernetes queue spin up pods correctly
- [ ] The custom images require `apache-airflow-providers-cncf-kubernetes` installed. Without it, the Kubernetes executor side won't work. If the image was built purely for Celery, it may be missing this provider.


🤖 Generated with [Claude Code](https://claude.ai/code)