### PR TITLE
Add per-environment DAG branch config

### DIFF
--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -29,6 +29,7 @@ module "dpe-sandbox-spacelift-development" {
   auto_deploy        = false
   auto_prune         = true
   git_branch         = var.git_branch
+  dags_git_branch    = "develop"
 
   space_name = "dpe-sandbox"
 
@@ -110,6 +111,7 @@ module "dpe-sandbox-spacelift-production" {
   aws_integration_id = var.org_sagebase_dpe_prod_aws_integration_id
   auto_deploy        = false
   git_branch         = var.git_branch
+  dags_git_branch    = "main"
 
   space_name = "dpe-k8s"
 

--- a/deployments/spacelift/dpe-k8s/main.tf
+++ b/deployments/spacelift/dpe-k8s/main.tf
@@ -30,6 +30,7 @@ locals {
     enable_otel_ingress    = var.enable_otel_ingress
     ssl_hostname           = var.ssl_hostname
     smtp_from              = var.smtp_from
+    dags_git_branch        = var.dags_git_branch
   }
 
   # Variables to be passed from the k8s stack to the deployments stack

--- a/deployments/spacelift/dpe-k8s/variables.tf
+++ b/deployments/spacelift/dpe-k8s/variables.tf
@@ -175,3 +175,9 @@ variable "smtp_from" {
   type        = string
   default     = ""
 }
+
+variable "dags_git_branch" {
+  description = "The orca-recipes branch to sync DAGs from"
+  type        = string
+  default     = "main"
+}

--- a/deployments/stacks/dpe-k8s-deployments/main.tf
+++ b/deployments/stacks/dpe-k8s-deployments/main.tf
@@ -64,6 +64,7 @@ module "airflow" {
   git_revision        = local.git_revision
   namespace           = "airflow"
   docker_access_token = var.docker_access_token
+  dags_git_branch     = var.dags_git_branch
 }
 
 module "postgres-cloud-native-operator" {

--- a/deployments/stacks/dpe-k8s-deployments/variables.tf
+++ b/deployments/stacks/dpe-k8s-deployments/variables.tf
@@ -109,3 +109,9 @@ variable "docker_access_token" {
   type        = string
   default     = ""
 }
+
+variable "dags_git_branch" {
+  description = "The orca-recipes branch to sync DAGs from"
+  type        = string
+  default     = "main"
+}

--- a/modules/apache-airflow/main.tf
+++ b/modules/apache-airflow/main.tf
@@ -71,6 +71,11 @@ spec:
       releaseName: airflow
       valueFiles:
       - $values/modules/apache-airflow/templates/values.yaml
+      parameters:
+      - name: dags.gitSync.branch
+        value: ${var.dags_git_branch}
+      - name: dags.gitSync.ref
+        value: ${var.dags_git_branch}
   - repoURL: 'https://github.com/Sage-Bionetworks-Workflows/eks-stack.git'
     targetRevision: ${var.git_revision}
     ref: values

--- a/modules/apache-airflow/variables.tf
+++ b/modules/apache-airflow/variables.tf
@@ -43,3 +43,9 @@ variable "docker_email" {
   default     = "dpe@sagebase.org"
   type        = string
 }
+
+variable "dags_git_branch" {
+  description = "The orca-recipes branch to sync DAGs from"
+  type        = string
+  default     = "main"
+}


### PR DESCRIPTION
# **Problem:**

- The DAG git-sync branch is hardcoded to `main` in `values.yaml`, meaning dev and prod always sync DAGs from the same branch with no way to test DAG changes in isolation

# **Solution:**

- Added a `dags_git_branch` variable threaded through the Spacelift stack modules and the Airflow module, overriding `dags.gitSync.branch` and `dags.gitSync.ref` via ArgoCD Helm parameters
- Dev environment syncs DAGs from `orca-recipes:develop`, prod from `orca-recipes:main`
- Staging falls back to the default of `main`

# **Testing:**

- Confirm dev Airflow is syncing DAGs from the `develop` branch of `orca-recipes`
- Confirm prod Airflow continues to sync from `main`

🤖 Generated with [Claude Code](https://claude.ai/code)