### PR TITLE
[IT-5076] Pin Spot Ocean worker AMI floor for CVE-2026-31431

### DIFF
--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -1,3 +1,10 @@
+locals {
+  # Minimum AL2023 EKS-optimized AMI release date (YYYYMMDD).
+  # Acts as a floor for the Spot Ocean worker AMI lookup. Bump for kernel CVE
+  # remediations (e.g., CVE-2026-31431 → v20260505 or later).
+  eks_min_ami_release_date = "20260505"
+}
+
 resource "spacelift_space" "development" {
   name             = "development"
   parent_space_id  = var.parent_space_id
@@ -59,6 +66,8 @@ module "dpe-sandbox-spacelift-development" {
   ses_email_identities = ["aws-dpe-dev@sagebase.org"]
   # Defines the email address that will be used as the sender of the email alerts
   smtp_from = "aws-dpe-dev@sagebase.org"
+
+  eks_min_ami_release_date = local.eks_min_ami_release_date
 }
 
 module "dpe-sandbox-spacelift-staging" {
@@ -99,6 +108,8 @@ module "dpe-sandbox-spacelift-staging" {
   ssl_hostname           = "staging.sagedpe.org"
   ses_email_identities = []
   smtp_from            = ""
+
+  eks_min_ami_release_date = local.eks_min_ami_release_date
 }
 
 module "dpe-sandbox-spacelift-production" {
@@ -140,6 +151,8 @@ module "dpe-sandbox-spacelift-production" {
   ses_email_identities = ["dpe@sagebase.org"]
   # Defines the email address that will be used as the sender of the email alerts
   smtp_from = "dpe@sagebase.org"
+
+  eks_min_ami_release_date = local.eks_min_ami_release_date
 }
 
 module "snowflake-spacelift-development" {

--- a/deployments/spacelift/dpe-k8s/main.tf
+++ b/deployments/spacelift/dpe-k8s/main.tf
@@ -19,17 +19,18 @@ locals {
   }
 
   k8s_stack_deployments_variables = {
-    spotinst_account       = var.spotinst_account
-    vpc_cidr_block         = var.vpc_cidr_block
-    cluster_name           = var.cluster_name
-    auto_deploy            = var.auto_deploy
-    auto_prune             = var.auto_prune
-    git_revision           = var.git_branch
-    aws_account_id         = var.aws_account_id
-    enable_cluster_ingress = var.enable_cluster_ingress
-    enable_otel_ingress    = var.enable_otel_ingress
-    ssl_hostname           = var.ssl_hostname
-    smtp_from              = var.smtp_from
+    spotinst_account         = var.spotinst_account
+    vpc_cidr_block           = var.vpc_cidr_block
+    cluster_name             = var.cluster_name
+    auto_deploy              = var.auto_deploy
+    auto_prune               = var.auto_prune
+    git_revision             = var.git_branch
+    aws_account_id           = var.aws_account_id
+    enable_cluster_ingress   = var.enable_cluster_ingress
+    enable_otel_ingress      = var.enable_otel_ingress
+    ssl_hostname             = var.ssl_hostname
+    smtp_from                = var.smtp_from
+    eks_min_ami_release_date = var.eks_min_ami_release_date
   }
 
   # Variables to be passed from the k8s stack to the deployments stack

--- a/deployments/spacelift/dpe-k8s/variables.tf
+++ b/deployments/spacelift/dpe-k8s/variables.tf
@@ -175,3 +175,8 @@ variable "smtp_from" {
   type        = string
   default     = ""
 }
+
+variable "eks_min_ami_release_date" {
+  description = "Minimum AL2023 EKS-optimized AMI release date (YYYYMMDD). Acts as a floor for the aws_ami lookup that pins the Spot Ocean image_id."
+  type        = string
+}

--- a/deployments/stacks/dpe-k8s-deployments/main.tf
+++ b/deployments/stacks/dpe-k8s-deployments/main.tf
@@ -12,6 +12,7 @@ module "sage-aws-eks-autoscaler" {
   spotinst_account       = var.spotinst_account
   single_az              = false
   desired_capacity       = 3
+  min_ami_release_date   = var.eks_min_ami_release_date
 }
 
 module "sage-aws-eks-addons" {

--- a/deployments/stacks/dpe-k8s-deployments/variables.tf
+++ b/deployments/stacks/dpe-k8s-deployments/variables.tf
@@ -109,3 +109,8 @@ variable "docker_access_token" {
   type        = string
   default     = ""
 }
+
+variable "eks_min_ami_release_date" {
+  description = "Minimum AL2023 EKS-optimized AMI release date (YYYYMMDD)."
+  type        = string
+}

--- a/modules/sage-aws-k8s-node-autoscaler/data.tf
+++ b/modules/sage-aws-k8s-node-autoscaler/data.tf
@@ -14,3 +14,18 @@ data "aws_secretsmanager_secret_version" "secret_credentials" {
   secret_id = data.aws_secretsmanager_secret.spotinst_token.id
 }
 
+data "aws_ami" "eks_worker_al2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amazon-eks-node-al2023-x86_64-standard-${data.aws_eks_cluster.cluster.version}-v${var.min_ami_release_date}*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+

--- a/modules/sage-aws-k8s-node-autoscaler/main.tf
+++ b/modules/sage-aws-k8s-node-autoscaler/main.tf
@@ -114,6 +114,7 @@ module "ocean-aws-k8s" {
   subnet_ids                       = var.single_az ? [var.private_vpc_subnet_ids[0]] : var.private_vpc_subnet_ids
   worker_instance_profile_arn      = aws_iam_instance_profile.profile.arn
   security_groups                  = [var.node_security_group_id]
+  ami_id                           = data.aws_ami.eks_worker_al2023.id
   is_aggressive_scale_down_enabled = true
   max_scale_down_percentage        = 33
   tags                             = var.tags

--- a/modules/sage-aws-k8s-node-autoscaler/variables.tf
+++ b/modules/sage-aws-k8s-node-autoscaler/variables.tf
@@ -54,3 +54,8 @@ variable "single_az" {
   description = "Single AZ"
   type        = bool
 }
+
+variable "min_ami_release_date" {
+  description = "Minimum AL2023 EKS-optimized AMI release date (YYYYMMDD). Acts as a floor for the aws_ami name-prefix filter; Spot Ocean uses the resolved AMI ID for new node launches."
+  type        = string
+}


### PR DESCRIPTION
## Summary
- Adds a single `eks_min_ami_release_date` knob in `deployments/main.tf` (currently `20260505`) and threads it through the Spacelift wrapper and `dpe-k8s-deployments` stack into `modules/sage-aws-k8s-node-autoscaler`.
- The autoscaler module resolves the AL2023 EKS-optimized AMI via an `aws_ami` data source filtered on `amazon-eks-node-al2023-x86_64-standard-<k8s-version>-v<date>*` and pins the result onto `module "ocean-aws-k8s"` via `ami_id`.
- Spot Ocean was previously auto-selecting AMIs below the `v20260505` patched release flagged by NIH STRIDES for CVE-2026-31431 (Linux kernel LPE). With this change, future CVE bumps are a one-line change to the local at the top of the stack.

## Test plan

I deployed some changes to the EKS DEV cluster to use a minimum AMI version strategy. I checked into the instance provisioner that we use and verified that this is ok per the remediation path in the parent ticket EKS: Update your Node Groups to the latest AMI Release (v20260505 or later).

```
{
  "architecture": "x86_64",
  "creationDate": "2026-05-05T23:23:14.000Z",
  "imageId": "ami-0bb984622f47bb856",
  "imageLocation": "amazon/amazon-eks-node-al2023-x86_64-standard-1.33-v20260505",
  "imageType": "machine",
  "public": true,
  "ownerId": "602401143452",
  "platformDetails": "Linux/UNIX",
  "usageOperation": "RunInstances",
  "productCodes": [],
  "state": "available",
  "blockDeviceMappings": [
    {
      "deviceName": "/dev/xvda",
      "ebs": {
        "deleteOnTermination": true,
        "iops": 3000,
        "snapshotId": "snap-0c6977b261a80aa51",
        "volumeSize": 20,
        "volumeType": "gp3",
        "throughput": 125,
        "encrypted": false
      }
    }
  ],
  "description": "EKS-optimized Kubernetes node based on Amazon Linux 2023, (k8s: 1.33.11, containerd: 2.*)",
  "enaSupport": true,
  "hypervisor": "xen",
  "imageOwnerAlias": "amazon",
  "name": "amazon-eks-node-al2023-x86_64-standard-1.33-v20260505",
  "rootDeviceName": "/dev/xvda",
  "rootDeviceType": "ebs",
  "sriovNetSupport": "simple",
  "tags": [],
  "virtualizationType": "hvm",
  "bootMode": "uefi-preferred",
  "deprecationTime": "2028-05-05T23:23:14.000Z",
  "imdsSupport": "v2.0"
}
```