### PR TITLE
[IT-4153] Add airflow-croissant IRSA role to replace static access key

### DIFF
--- a/deployments/stacks/dpe-k8s-deployments/main.tf
+++ b/deployments/stacks/dpe-k8s-deployments/main.tf
@@ -59,12 +59,15 @@ module "airflow" {
   depends_on = [module.victoria-metrics, module.argo-cd]
   # source       = "spacelift.io/sagebionetworks/airflow/aws"
   # version      = "0.4.0"
-  source              = "../../../modules/apache-airflow"
-  auto_deploy         = var.auto_deploy
-  auto_prune          = var.auto_prune
-  git_revision        = local.git_revision
-  namespace           = "airflow"
-  docker_access_token = var.docker_access_token
+  source                    = "../../../modules/apache-airflow"
+  auto_deploy               = var.auto_deploy
+  auto_prune                = var.auto_prune
+  git_revision              = local.git_revision
+  namespace                 = "airflow"
+  docker_access_token       = var.docker_access_token
+  cluster_name              = var.cluster_name
+  aws_account_id            = var.aws_account_id
+  cluster_oidc_provider_arn = var.cluster_oidc_provider_arn
 }
 
 module "postgres-cloud-native-operator" {

--- a/modules/apache-airflow/README.md
+++ b/modules/apache-airflow/README.md
@@ -80,3 +80,12 @@ Transitive dependencies may also need to be updated when building a new image fo
 airflow, for example `py-orca` was updated in this example PR: <https://github.com/Sage-Bionetworks-Workflows/py-orca/pull/45>.
 Additionally, this PR covers what was completed in order to update the 
 requirements/dockerfile: <https://github.com/Sage-Bionetworks-Workflows/orca-recipes/pull/71>.
+
+## Granting AWS permissions to airflow workloads
+Airflow pods assume an IRSA role (see `iam.tf`) to access AWS resources. Whenever a
+workload needs to read or write an AWS resource that the role does not already permit —
+for example a new S3 bucket, a new secret prefix, or a different AWS service — the IAM
+policy in `iam.tf` must be updated to grant those actions. Anything AWS-permission
+related is not covered automatically, so watch for it when adding new stacks or DAGs.
+The current buckets/permissions in `iam.tf` are one such example: they were added so
+those DAGs could read/write/delete their data.

--- a/modules/apache-airflow/iam.tf
+++ b/modules/apache-airflow/iam.tf
@@ -1,6 +1,6 @@
 locals {
-  # Only provisioned on the prod cluster, matching the croissant S3 buckets.
-  create_croissant_irsa = var.cluster_name == "dpe-k8"
+  # Only provisioned on the prod cluster, matching the S3 buckets below.
+  create_airflow_irsa = var.cluster_name == "dpe-k8"
 
   # The trust policy condition keys are the OIDC provider URL without the scheme.
   oidc_provider_url = replace(
@@ -9,26 +9,28 @@ locals {
     ""
   )
 
-  croissant_service_account_subjects = [
+  airflow_service_account_subjects = [
     "system:serviceaccount:${var.namespace}:airflow-worker",
     "system:serviceaccount:${var.namespace}:airflow-scheduler",
     "system:serviceaccount:${var.namespace}:airflow-triggerer",
     "system:serviceaccount:${var.namespace}:airflow-webserver",
   ]
 
-  croissant_buckets = [
+  # S3 buckets the airflow workloads are permitted to access. Add buckets here as
+  # new workloads require them.
+  airflow_s3_buckets = [
     "synapse-croissant-metadata",
     "synapse-croissant-metadata-minimal",
   ]
 
-  croissant_role_arn = local.create_croissant_irsa ? aws_iam_role.airflow_croissant[0].arn : ""
+  airflow_irsa_role_arn = local.create_airflow_irsa ? aws_iam_role.airflow_irsa[0].arn : ""
 }
 
-resource "aws_iam_role" "airflow_croissant" {
-  count = local.create_croissant_irsa ? 1 : 0
+resource "aws_iam_role" "airflow_irsa" {
+  count = local.create_airflow_irsa ? 1 : 0
 
-  name        = "airflow-croissant"
-  description = "IRSA role assumed by Airflow pods to read airflow/* secrets and CRUD the croissant S3 buckets."
+  name        = "airflow-irsa"
+  description = "IRSA role assumed by Airflow pods to read airflow/* secrets and CRUD the permitted S3 buckets."
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -42,7 +44,7 @@ resource "aws_iam_role" "airflow_croissant" {
         Condition = {
           StringEquals = {
             "${local.oidc_provider_url}:aud" = "sts.amazonaws.com"
-            "${local.oidc_provider_url}:sub" = local.croissant_service_account_subjects
+            "${local.oidc_provider_url}:sub" = local.airflow_service_account_subjects
           }
         }
       }
@@ -50,32 +52,32 @@ resource "aws_iam_role" "airflow_croissant" {
   })
 }
 
-resource "aws_iam_policy" "airflow_croissant" {
-  count = local.create_croissant_irsa ? 1 : 0
+resource "aws_iam_policy" "airflow_irsa" {
+  count = local.create_airflow_irsa ? 1 : 0
 
-  name        = "airflow-croissant"
-  description = "Read airflow/* secrets and CRUD the croissant S3 buckets. Replaces the airflow-secrets-backend IAM user access keys."
+  name        = "airflow-irsa"
+  description = "Read airflow/* secrets and CRUD the permitted S3 buckets. Replaces the airflow-secrets-backend IAM user access keys."
 
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "CroissantBucketObjects"
+        Sid    = "AirflowBucketObjects"
         Effect = "Allow"
         Action = [
           "s3:PutObject",
           "s3:GetObject",
           "s3:DeleteObject",
         ]
-        Resource = [for bucket in local.croissant_buckets : "arn:aws:s3:::${bucket}/*"]
+        Resource = [for bucket in local.airflow_s3_buckets : "arn:aws:s3:::${bucket}/*"]
       },
       {
-        Sid    = "CroissantBucketList"
+        Sid    = "AirflowBucketList"
         Effect = "Allow"
         Action = [
           "s3:ListBucket",
         ]
-        Resource = [for bucket in local.croissant_buckets : "arn:aws:s3:::${bucket}"]
+        Resource = [for bucket in local.airflow_s3_buckets : "arn:aws:s3:::${bucket}"]
       },
       {
         Sid    = "AirflowSecretsRead"
@@ -100,9 +102,9 @@ resource "aws_iam_policy" "airflow_croissant" {
   })
 }
 
-resource "aws_iam_role_policy_attachment" "airflow_croissant" {
-  count = local.create_croissant_irsa ? 1 : 0
+resource "aws_iam_role_policy_attachment" "airflow_irsa" {
+  count = local.create_airflow_irsa ? 1 : 0
 
-  role       = aws_iam_role.airflow_croissant[0].name
-  policy_arn = aws_iam_policy.airflow_croissant[0].arn
+  role       = aws_iam_role.airflow_irsa[0].name
+  policy_arn = aws_iam_policy.airflow_irsa[0].arn
 }

--- a/modules/apache-airflow/iam.tf
+++ b/modules/apache-airflow/iam.tf
@@ -1,0 +1,108 @@
+locals {
+  # Only provisioned on the prod cluster, matching the croissant S3 buckets.
+  create_croissant_irsa = var.cluster_name == "dpe-k8"
+
+  # The trust policy condition keys are the OIDC provider URL without the scheme.
+  oidc_provider_url = replace(
+    element(split("oidc-provider/", var.cluster_oidc_provider_arn), 1),
+    "https://",
+    ""
+  )
+
+  croissant_service_account_subjects = [
+    "system:serviceaccount:${var.namespace}:airflow-worker",
+    "system:serviceaccount:${var.namespace}:airflow-scheduler",
+    "system:serviceaccount:${var.namespace}:airflow-triggerer",
+    "system:serviceaccount:${var.namespace}:airflow-webserver",
+  ]
+
+  croissant_buckets = [
+    "synapse-croissant-metadata",
+    "synapse-croissant-metadata-minimal",
+  ]
+
+  croissant_role_arn = local.create_croissant_irsa ? aws_iam_role.airflow_croissant[0].arn : ""
+}
+
+resource "aws_iam_role" "airflow_croissant" {
+  count = local.create_croissant_irsa ? 1 : 0
+
+  name        = "airflow-croissant"
+  description = "IRSA role assumed by Airflow pods to read airflow/* secrets and CRUD the croissant S3 buckets."
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = var.cluster_oidc_provider_arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${local.oidc_provider_url}:aud" = "sts.amazonaws.com"
+            "${local.oidc_provider_url}:sub" = local.croissant_service_account_subjects
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "airflow_croissant" {
+  count = local.create_croissant_irsa ? 1 : 0
+
+  name        = "airflow-croissant"
+  description = "Read airflow/* secrets and CRUD the croissant S3 buckets. Replaces the airflow-secrets-backend IAM user access keys."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "CroissantBucketObjects"
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:DeleteObject",
+        ]
+        Resource = [for bucket in local.croissant_buckets : "arn:aws:s3:::${bucket}/*"]
+      },
+      {
+        Sid    = "CroissantBucketList"
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+        ]
+        Resource = [for bucket in local.croissant_buckets : "arn:aws:s3:::${bucket}"]
+      },
+      {
+        Sid    = "AirflowSecretsRead"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue",
+        ]
+        Resource = [
+          "arn:aws:secretsmanager:us-east-1:${var.aws_account_id}:secret:airflow/connections/*",
+          "arn:aws:secretsmanager:us-east-1:${var.aws_account_id}:secret:airflow/variables/*",
+        ]
+      },
+      {
+        Sid    = "AirflowSecretsList"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:ListSecrets",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "airflow_croissant" {
+  count = local.create_croissant_irsa ? 1 : 0
+
+  role       = aws_iam_role.airflow_croissant[0].name
+  policy_arn = aws_iam_policy.airflow_croissant[0].arn
+}

--- a/modules/apache-airflow/main.tf
+++ b/modules/apache-airflow/main.tf
@@ -71,6 +71,25 @@ spec:
       releaseName: airflow
       valueFiles:
       - $values/modules/apache-airflow/templates/values.yaml
+%{if local.create_croissant_irsa}
+      values: |
+        workers:
+          serviceAccount:
+            annotations:
+              eks.amazonaws.com/role-arn: ${local.croissant_role_arn}
+        scheduler:
+          serviceAccount:
+            annotations:
+              eks.amazonaws.com/role-arn: ${local.croissant_role_arn}
+        triggerer:
+          serviceAccount:
+            annotations:
+              eks.amazonaws.com/role-arn: ${local.croissant_role_arn}
+        webserver:
+          serviceAccount:
+            annotations:
+              eks.amazonaws.com/role-arn: ${local.croissant_role_arn}
+%{endif}
   - repoURL: 'https://github.com/Sage-Bionetworks-Workflows/eks-stack.git'
     targetRevision: ${var.git_revision}
     ref: values

--- a/modules/apache-airflow/main.tf
+++ b/modules/apache-airflow/main.tf
@@ -71,24 +71,24 @@ spec:
       releaseName: airflow
       valueFiles:
       - $values/modules/apache-airflow/templates/values.yaml
-%{if local.create_croissant_irsa}
+%{if local.create_airflow_irsa}
       values: |
         workers:
           serviceAccount:
             annotations:
-              eks.amazonaws.com/role-arn: ${local.croissant_role_arn}
+              eks.amazonaws.com/role-arn: ${local.airflow_irsa_role_arn}
         scheduler:
           serviceAccount:
             annotations:
-              eks.amazonaws.com/role-arn: ${local.croissant_role_arn}
+              eks.amazonaws.com/role-arn: ${local.airflow_irsa_role_arn}
         triggerer:
           serviceAccount:
             annotations:
-              eks.amazonaws.com/role-arn: ${local.croissant_role_arn}
+              eks.amazonaws.com/role-arn: ${local.airflow_irsa_role_arn}
         webserver:
           serviceAccount:
             annotations:
-              eks.amazonaws.com/role-arn: ${local.croissant_role_arn}
+              eks.amazonaws.com/role-arn: ${local.airflow_irsa_role_arn}
 %{endif}
   - repoURL: 'https://github.com/Sage-Bionetworks-Workflows/eks-stack.git'
     targetRevision: ${var.git_revision}

--- a/modules/apache-airflow/variables.tf
+++ b/modules/apache-airflow/variables.tf
@@ -22,7 +22,7 @@ variable "namespace" {
 }
 
 variable "cluster_name" {
-  description = "EKS cluster name. The croissant IRSA role and its service account annotations are only created on the prod cluster (dpe-k8)."
+  description = "EKS cluster name. The airflow IRSA role and its service account annotations are only created on the prod cluster (dpe-k8)."
   type        = string
 }
 
@@ -32,7 +32,7 @@ variable "aws_account_id" {
 }
 
 variable "cluster_oidc_provider_arn" {
-  description = "ARN of the EKS cluster OIDC provider, used as the federated principal for the croissant IRSA role."
+  description = "ARN of the EKS cluster OIDC provider, used as the federated principal for the airflow IRSA role."
   type        = string
   default     = ""
 }

--- a/modules/apache-airflow/variables.tf
+++ b/modules/apache-airflow/variables.tf
@@ -21,6 +21,22 @@ variable "namespace" {
   type        = string
 }
 
+variable "cluster_name" {
+  description = "EKS cluster name. The croissant IRSA role and its service account annotations are only created on the prod cluster (dpe-k8)."
+  type        = string
+}
+
+variable "aws_account_id" {
+  description = "AWS account ID"
+  type        = string
+}
+
+variable "cluster_oidc_provider_arn" {
+  description = "ARN of the EKS cluster OIDC provider, used as the federated principal for the croissant IRSA role."
+  type        = string
+  default     = ""
+}
+
 variable "docker_server" {
   description = "The docker registry URL"
   default     = "https://index.docker.io/v1/"


### PR DESCRIPTION
# **Problem:**

Prod Airflow reaches the `synapse-croissant-metadata[-minimal]` S3 buckets and the `airflow/*` Secrets Manager secrets using long-lived access keys on the `airflow-secrets-backend` IAM user. The S3 key is stored *inside* the `AWS_SYNAPSE_CROISSANT_METADATA_S3_CONN` connection secret. These keys must be manually rotated every 90 days to satisfy CIS AWS Foundations Benchmark 1.14 ([IT-4153](https://sagebionetworks.jira.com/browse/IT-4153)), which recurs indefinitely.

Verified current state:
- Airflow pods have **no** IRSA annotation / Pod Identity today; they reach AWS via the node instance role `work_profile_iam_role_dpe-k8` (`SecretsManagerReadWrite`) for secret resolution, and the static key (from the connection secret) for croissant S3.
- Both croissant DAGs use the single connection `AWS_SYNAPSE_CROISSANT_METADATA_S3_CONN` but write to **two** buckets.
- DAG parsing calls `Variable.get(...)` at module scope (`synapse-dataset-to-croissant.py`), so the **scheduler** (and webserver, which imports DAGs) also read Secrets Manager — not just the worker.

# **Solution:**

Introduce IRSA so prod Airflow assumes an IAM role via the cluster OIDC provider instead of using a static key.

- **New `airflow-croissant` IAM role** (`modules/apache-airflow/iam.tf`), gated to the prod cluster (`cluster_name == "dpe-k8"`):
  - **Trust** scoped to an explicit list of the four service accounts — `system:serviceaccount:airflow:airflow-{worker,scheduler,triggerer,webserver}` — via `sub`/`aud` conditions on the OIDC provider (closes the open-trust gap the existing single-bucket croissant roles have).
  - **Policy is a superset of the pods' current ambient access** so nothing loses access: S3 `Put/Get/Delete/ListBucket` on **both** croissant buckets (mirrors the inline `croissant-crud-for-airflow` user policy) **plus** `secretsmanager:GetSecretValue` on `airflow/connections/*` and `airflow/variables/*`, and `ListSecrets`.
- **Service account annotations** injected via **prod-only inline `helm.values`** in the ArgoCD Application (`modules/apache-airflow/main.tf`), rather than the git-synced `values.yaml` which is shared with staging. Staging (same account, separate cluster/OIDC) renders no annotation and keeps its ambient node-role behavior.
- Wired `cluster_name` / `aws_account_id` / `cluster_oidc_provider_arn` into the module from `dpe-k8s-deployments`.

Secrets Manager scope is intentionally the full `airflow/*` prefixes (not just croissant): once the worker is annotated, resolving **every** connection (e.g. `AWS_TOWER_PROD_S3_CONN`) goes through the role, so a narrower scope would break unrelated DAGs.

No KMS grant is needed (all `airflow/*` secrets use the AWS-managed default key) and no `PutObjectAcl` (the croissant `S3Hook` only sets `ContentType`; public-read is bucket-policy based).

# **Testing:**

- `tofu fmt` clean; `tofu validate` passes on the module.
- Rendered the ArgoCD Application template for both clusters: prod emits the inline `values:` block annotating all four SAs with the correct role ARN; staging emits no block. Confirmed the block parses as valid YAML into the structure the Airflow chart expects.
- Verified the OIDC-URL derivation against the real provider ARN produces the correct `...:sub` / `...:aud` condition keys.

## Cutover plan (perform in order — zero-gap, reversible)

> The static key stays valid until step 3, so there is always a working path to S3.

1. **Merge this PR.** ArgoCD syncs; **roll** `worker`, `scheduler`, `triggerer`, `webserver` so the SA token/annotation is injected.
2. **Verify the overlap** while the key is *still* in the secret:
   - On a fresh worker pod: `env | grep AWS_` shows `AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE`.
   - From that pod: `aws s3 ls s3://synapse-croissant-metadata` and `s3://synapse-croissant-metadata-minimal` succeed (via IRSA).
   - Confirm the scheduler parses a croissant DAG **and** a Tower/challenge DAG (`AWS_TOWER_PROD_S3_CONN`) with no Secrets Manager errors.
3. **Strip the static creds** from the `AWS_SYNAPSE_CROISSANT_METADATA_S3_CONN` secret (manual; operationally managed):
   `{"conn_type":"aws","login":"AKIA…","password":"…"}` → `{"conn_type":"aws","region_name":"us-east-1"}`.
4. **Validate end-to-end:** trigger both croissant DAGs; confirm S3 write/list/delete succeed and the public object URL serves. Rollback if needed = re-add the key to the secret.

## Follow-up (separate, after both this and the orca-recipes SSO PR are verified live)
- Confirm via `aws iam get-access-key-last-used` the S3 key has gone idle, then delete both access keys, the `airflow-secrets-backend` user, and its policies; resolve IT-4153. (Companion PR: developer SSO migration in `orca-recipes`.)

[IT-4153]: https://sagebionetworks.jira.com/browse/IT-4153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ